### PR TITLE
Remove version numbers from templates

### DIFF
--- a/_build/templates/mod/collection.hbs
+++ b/_build/templates/mod/collection.hbs
@@ -1,7 +1,7 @@
 define(['./make_', '../array/{{name}}', '../object/{{name}}'], function (make, arr{{u_name}}, obj{{u_name}}) {
 
     /**
-     * @version 0.1.0 ({{date}})
+     *
      */
     return make(arr{{u_name}}, obj{{u_name}});
 

--- a/_build/templates/mod/default.hbs
+++ b/_build/templates/mod/default.hbs
@@ -1,7 +1,7 @@
 define(function () {
 
     /**
-     * @version 0.1.0 ({{date}})
+     *
      */
     function {{name}}(){
         throw new Error('{{name}} wasn\'t implemented yet.');


### PR DESCRIPTION
I think this is only sensible since #8 was applied. Do we want JSDoc comments at all in the source code or should they be totally removed?
