### PR TITLE
shorthand syntax to object/* & collection/* functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Next
 ----
 
  - add `object/matches`.
- - add shorthand syntax to `array/*` methods.
+ - add shorthand syntax to `array/*`, `object/*` and `collection/*` methods.
  - improve `number/sign` behavior when value is zero (returns zero).
 
 

--- a/src/collection/filter.js
+++ b/src/collection/filter.js
@@ -1,9 +1,10 @@
-define(['./forEach'], function (forEach) {
+define(['./forEach', '../function/makeIterator_'], function (forEach, makeIterator) {
 
     /**
      * filter collection values, returns array.
      */
     function filter(list, iterator, context) {
+        iterator = makeIterator(iterator);
         var results = [];
         if (!list) {
             return results;

--- a/src/collection/map.js
+++ b/src/collection/map.js
@@ -1,9 +1,10 @@
-define(['../lang/isObject', '../object/values', '../array/map'], function (isObject, values, arrMap) {
+define(['../lang/isObject', '../object/values', '../array/map', '../function/makeIterator_'], function (isObject, values, arrMap, makeIterator) {
 
     /**
      * Map collection values, returns Array.
      */
     function map(list, callback, thisObj) {
+        callback = makeIterator(callback);
         // list.length to check array-like object, if not array-like
         // we simply map all the object values
         if( isObject(list) && list.length == null ){

--- a/src/collection/reject.js
+++ b/src/collection/reject.js
@@ -1,9 +1,10 @@
-define(['./filter'], function (filter) {
+define(['./filter', '../function/makeIterator_'], function (filter, makeIterator) {
 
     /**
      * Inverse or collection/filter
      */
     function reject(list, iterator, context) {
+        iterator = makeIterator(iterator);
         return filter(list, function(value, index, list) {
             return !iterator.call(context, value, index, list);
         }, context);

--- a/src/object/every.js
+++ b/src/object/every.js
@@ -1,12 +1,15 @@
-define(['./forOwn'], function(forOwn) {
+define(['./forOwn', '../function/makeIterator_'], function(forOwn, makeIterator) {
 
     /**
      * Object every
      */
     function every(obj, callback, thisObj) {
+        callback = makeIterator(callback);
         var result = true;
         forOwn(obj, function(val, key) {
-            if (callback.call(thisObj, val, key, obj) === false) {
+            // we consider any falsy values as "false" on purpose so shorthand
+            // syntax can be used to check property existence
+            if (!callback.call(thisObj, val, key, obj)) {
                 result = false;
                 return false; // break
             }

--- a/src/object/filter.js
+++ b/src/object/filter.js
@@ -1,10 +1,11 @@
-define(['./forOwn'], function(forOwn) {
+define(['./forOwn', '../function/makeIterator_'], function(forOwn, makeIterator) {
 
     /**
      * Creates a new object with all the properties where the callback returns
      * true.
      */
     function filterValues(obj, callback, thisObj) {
+        callback = makeIterator(callback);
         var output = {};
         forOwn(obj, function(value, key, obj) {
             if (callback.call(thisObj, value, key, obj)) {

--- a/src/object/find.js
+++ b/src/object/find.js
@@ -1,9 +1,10 @@
-define(['./some'], function(some) {
+define(['./some', '../function/makeIterator_'], function(some, makeIterator) {
 
     /**
      * Returns first item that matches criteria
      */
     function find(obj, callback, thisObj) {
+        callback = makeIterator(callback);
         var result;
         some(obj, function(value, key, obj) {
             if (callback.call(thisObj, value, key, obj)) {

--- a/src/object/map.js
+++ b/src/object/map.js
@@ -1,10 +1,11 @@
-define(['./forOwn'], function(forOwn) {
+define(['./forOwn', '../function/makeIterator_'], function(forOwn, makeIterator) {
 
     /**
      * Creates a new object where all the values are the result of calling
      * `callback`.
      */
     function mapValues(obj, callback, thisObj) {
+        callback = makeIterator(callback);
         var output = {};
         forOwn(obj, function(val, key, obj) {
             output[key] = callback.call(thisObj, val, key, obj);

--- a/src/object/matches.js
+++ b/src/object/matches.js
@@ -1,12 +1,18 @@
-define(['./every'], function (every) {
+define(['./forOwn'], function (forOwn) {
 
     /**
      * checks if a object contains all given properties/values
      */
     function matches(target, props){
-        return every(props, function(val, key){
-            return target[key] === val;
+        // can't use "object/every" because of circular dependency
+        var result = true;
+        forOwn(props, function(val, key){
+            if (target[key] !== val) {
+                // break loop at first difference
+                return (result = false);
+            }
         });
+        return result;
     }
 
     return matches;

--- a/src/object/reject.js
+++ b/src/object/reject.js
@@ -1,9 +1,10 @@
-define(['./filter'], function (filter) {
+define(['./filter', '../function/makeIterator_'], function (filter, makeIterator) {
 
     /**
      * Object reject
      */
     function reject(obj, callback, thisObj) {
+        callback = makeIterator(callback);
         return filter(obj, function(value, index, obj) {
             return !callback.call(thisObj, value, index, obj);
         }, thisObj);

--- a/src/object/some.js
+++ b/src/object/some.js
@@ -1,9 +1,10 @@
-define(['./forOwn'], function(forOwn) {
+define(['./forOwn', '../function/makeIterator_'], function(forOwn, makeIterator) {
 
     /**
      * Object some
      */
     function some(obj, callback, thisObj) {
+        callback = makeIterator(callback);
         var result = false;
         forOwn(obj, function(val, key) {
             if (callback.call(thisObj, val, key, obj)) {

--- a/tests/spec/collection/spec-every.js
+++ b/tests/spec/collection/spec-every.js
@@ -67,6 +67,43 @@ define(['mout/collection/every'], function(every){
             expect( every({}, isEven) ).toBe( true );
         });
 
-    });
 
+
+        it('should support shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( every(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( true );
+            expect( every(obj, {lorem:'ipsum', id:1}) ).toEqual( false );
+            expect( every(obj, {amet:123}) ).toEqual( false );
+
+            expect( every(arr, {foo:'bar', lorem:'ipsum'}) ).toEqual( true );
+            expect( every(arr, {lorem:'ipsum', id:1}) ).toEqual( false );
+            expect( every(arr, {amet:123}) ).toEqual( false );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( every(obj, 'foo') ).toEqual( true );
+            expect( every(obj, 'id') ).toEqual( false );
+            expect( every(obj, 'amet') ).toEqual( false );
+
+            expect( every(arr, 'foo') ).toEqual( true );
+            expect( every(arr, 'id') ).toEqual( false );
+            expect( every(arr, 'amet') ).toEqual( false );
+        });
+
+
+    });
 });

--- a/tests/spec/collection/spec-filter.js
+++ b/tests/spec/collection/spec-filter.js
@@ -34,6 +34,42 @@ define(['mout/collection/filter'], function(filter){
             expect( result ).toEqual( ['a', 'c'] );
         });
 
-    });
 
+        it('should support shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( filter(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( [obj[0], obj[1], obj[2]] );
+            expect( filter(obj, {lorem:'ipsum', id:1}) ).toEqual( [obj[0]] );
+            expect( filter(obj, {amet:123}) ).toEqual( [] );
+
+            expect( filter(arr, {foo:'bar', lorem:'ipsum'}) ).toEqual( [obj[0], obj[1], obj[2]] );
+            expect( filter(arr, {lorem:'ipsum', id:1}) ).toEqual( [obj[0]] );
+            expect( filter(arr, {amet:123}) ).toEqual( [] );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( filter(obj, 'foo') ).toEqual( [obj[0], obj[1], obj[2]] );
+            expect( filter(obj, 'id') ).toEqual( [obj[0], obj[1]] );
+            expect( filter(obj, 'amet') ).toEqual( [] );
+
+            expect( filter(arr, 'foo') ).toEqual( [obj[0], obj[1], obj[2]] );
+            expect( filter(arr, 'id') ).toEqual( [obj[0], obj[1]] );
+            expect( filter(arr, 'amet') ).toEqual( [] );
+        });
+
+
+    });
 });

--- a/tests/spec/collection/spec-find.js
+++ b/tests/spec/collection/spec-find.js
@@ -33,6 +33,37 @@ define(['mout/collection/find'], function(find){
 
         });
 
-    });
 
+        it('should support shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( find(obj, {lorem:'ipsum', id:1}) ).toEqual( obj[0] );
+            expect( find(obj, {amet:123}) ).toBeUndefined();
+
+            expect( find(arr, {lorem:'ipsum', id:1}) ).toEqual( obj[0] );
+            expect( find(arr, {amet:123}) ).toBeUndefined();
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:0},
+                '1' : {foo:'bar', lorem:'ipsum', id:1}
+            };
+            var arr = [obj[0], obj[1]];
+
+            expect( find(obj, 'id') ).toEqual( obj[1] );
+            expect( find(obj, 'amet') ).toBeUndefined();
+
+            expect( find(arr, 'id') ).toEqual( obj[1] );
+            expect( find(arr, 'amet') ).toBeUndefined();
+        });
+
+
+    });
 });

--- a/tests/spec/collection/spec-map.js
+++ b/tests/spec/collection/spec-map.js
@@ -36,6 +36,24 @@ define(['mout/collection/map'], function(map){
             expect( result ).toEqual( ['0-1', '1-b', '2-c'] );
         });
 
-    });
 
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( map(obj, 'foo') ).toEqual( ['bar', 'bar', 'bar'] );
+            expect( map(obj, 'id') ).toEqual( [1,2,0] );
+            expect( map(obj, 'amet') ).toEqual( [undefined,undefined,undefined] );
+
+            expect( map(arr, 'foo') ).toEqual( ['bar', 'bar', 'bar'] );
+            expect( map(arr, 'id') ).toEqual( [1,2,0] );
+            expect( map(arr, 'amet') ).toEqual( [undefined,undefined,undefined] );
+        });
+
+
+    });
 });

--- a/tests/spec/collection/spec-max.js
+++ b/tests/spec/collection/spec-max.js
@@ -50,6 +50,23 @@ define(['mout/collection/max'], function(max){
 
         });
 
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( max(obj, 'id') ).toEqual( obj[1] );
+            expect( max(obj, 'amet') ).toBeUndefined();
+
+            expect( max(arr, 'id') ).toEqual( obj[1] );
+            expect( max(arr, 'amet') ).toBeUndefined();
+        });
+
+
     });
 
 });

--- a/tests/spec/collection/spec-min.js
+++ b/tests/spec/collection/spec-min.js
@@ -50,6 +50,23 @@ define(['mout/collection/min'], function(min){
 
         });
 
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( min(obj, 'id') ).toEqual( obj[2] );
+            expect( min(obj, 'amet') ).toBeUndefined();
+
+            expect( min(arr, 'id') ).toEqual( obj[2] );
+            expect( min(arr, 'amet') ).toBeUndefined();
+        });
+
+
     });
 
 });

--- a/tests/spec/collection/spec-reject.js
+++ b/tests/spec/collection/spec-reject.js
@@ -58,6 +58,43 @@ define(['mout/collection/reject', 'mout/collection/size'], function(reject, size
             expect(result).toEqual([]);
         });
 
+
+        it('should support shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( reject(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( [] );
+            expect( reject(obj, {lorem:'ipsum', id:1}) ).toEqual( [obj[1], obj[2]] );
+            expect( reject(obj, {amet:123}) ).toEqual( arr );
+
+            expect( reject(arr, {foo:'bar', lorem:'ipsum'}) ).toEqual( [] );
+            expect( reject(arr, {lorem:'ipsum', id:1}) ).toEqual( [obj[1], obj[2]] );
+            expect( reject(arr, {amet:123}) ).toEqual( arr );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( reject(obj, 'foo') ).toEqual( [] );
+            expect( reject(obj, 'id') ).toEqual( [obj[2]] );
+            expect( reject(obj, 'amet') ).toEqual( [obj[0], obj[1], obj[2]] );
+
+            expect( reject(arr, 'foo') ).toEqual( [] );
+            expect( reject(arr, 'id') ).toEqual( [obj[2]] );
+            expect( reject(arr, 'amet') ).toEqual( [obj[0], obj[1], obj[2]] );
+        });
+
+
     });
 
 });

--- a/tests/spec/collection/spec-some.js
+++ b/tests/spec/collection/spec-some.js
@@ -63,6 +63,42 @@ define(['mout/collection/some'], function(some){
             expect( a ).toEqual( compare );
         });
 
-    });
 
+        it('should support shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( some(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( true );
+            expect( some(obj, {lorem:'ipsum', id:1}) ).toEqual( true );
+            expect( some(obj, {amet:123}) ).toEqual( false );
+
+            expect( some(arr, {foo:'bar', lorem:'ipsum'}) ).toEqual( true );
+            expect( some(arr, {lorem:'ipsum', id:1}) ).toEqual( true );
+            expect( some(arr, {amet:123}) ).toEqual( false );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                '0' : {foo:'bar', lorem:'ipsum', id:1},
+                '1' : {foo:'bar', lorem:'ipsum', id:2},
+                '2' : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            var arr = [obj[0], obj[1], obj[2]];
+
+            expect( some(obj, 'foo') ).toEqual( true );
+            expect( some(obj, 'id') ).toEqual( true );
+            expect( some(obj, 'amet') ).toEqual( false );
+
+            expect( some(arr, 'foo') ).toEqual( true );
+            expect( some(arr, 'id') ).toEqual( true );
+            expect( some(arr, 'amet') ).toEqual( false );
+        });
+
+
+    });
 });

--- a/tests/spec/object/spec-every.js
+++ b/tests/spec/object/spec-every.js
@@ -6,6 +6,7 @@ define(['mout/object/every'], function(every){
             return (val % 2 === 0);
         };
 
+
         it('should work on normal object', function () {
             var a1 = {a: 1, b: 2, c: 3};
             var a2 = {a: 1, b: 3, c: 5};
@@ -16,9 +17,11 @@ define(['mout/object/every'], function(every){
             expect( every(a3, isEven) ).toBe( true );
         });
 
+
         it('should work on empty objects', function () {
             expect( every({}, isEven) ).toBe( true );
         });
+
 
         it('should avoid don\'t enum bug on IE 7-8', function () {
             var a1 = {a:2, toString:3};
@@ -26,6 +29,31 @@ define(['mout/object/every'], function(every){
             expect( every(a1, isEven) ).toBe( false );
             expect( every(a2, isEven) ).toBe( true );
         });
+
+
+        it('should support shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            expect( every(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( true );
+            expect( every(obj, {lorem:'ipsum', id:1}) ).toEqual( false );
+            expect( every(obj, {amet:123}) ).toEqual( false );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            expect( every(obj, 'foo') ).toEqual( true );
+            expect( every(obj, 'id') ).toEqual( false );
+            expect( every(obj, 'amet') ).toEqual( false );
+        });
+
 
     });
 

--- a/tests/spec/object/spec-filter.js
+++ b/tests/spec/object/spec-filter.js
@@ -57,6 +57,30 @@ define(['mout/object/filter'], function(filter) {
             expect(result).toEqual(obj);
         });
 
-    });
 
+        it('should support shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            expect( filter(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( obj );
+            expect( filter(obj, {lorem:'ipsum', id:1}) ).toEqual( {a:obj.a} );
+            expect( filter(obj, {amet:123}) ).toEqual( {} );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            expect( filter(obj, 'foo') ).toEqual( obj );
+            expect( filter(obj, 'id') ).toEqual( {a:obj.a, b:obj.b} );
+            expect( filter(obj, 'amet') ).toEqual( {} );
+        });
+
+
+    });
 });

--- a/tests/spec/object/spec-find.js
+++ b/tests/spec/object/spec-find.js
@@ -32,6 +32,29 @@ define(['mout/object/find'], function(find){
             }) ).toEqual( 'foo123' );
         });
 
+
+        it('should support shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            expect( find(obj, {lorem:'ipsum', id:1}) ).toEqual( obj.a );
+            expect( find(obj, {amet:123}) ).toBeUndefined();
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:1, bar:null},
+                b : {foo:0, bar:''},
+                c : {foo:0, bar:'amet'}
+            };
+            expect( find(obj, 'foo') ).toEqual( obj.a );
+            expect( find(obj, 'bar') ).toEqual( obj.c );
+            expect( find(obj, 'amet') ).toBeUndefined();
+        });
+
     });
 
 });

--- a/tests/spec/object/spec-map.js
+++ b/tests/spec/object/spec-map.js
@@ -51,8 +51,20 @@ define(['mout/object/map'], function(map) {
             var obj = { foo: null },
                 thisObj = {};
 
-            var result = map(obj, function() { return this }, thisObj);
+            var result = map(obj, function() { return this; }, thisObj);
             expect(result.foo).toBe(thisObj);
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            expect( map(obj, 'foo') ).toEqual( {a:'bar', b:'bar',c:'bar'} );
+            expect( map(obj, 'id') ).toEqual( {a:1,b:2,c:0} );
+            expect( map(obj, 'amet') ).toEqual( {a:undefined,b:undefined,c:undefined} );
         });
 
     });

--- a/tests/spec/object/spec-max.js
+++ b/tests/spec/object/spec-max.js
@@ -26,6 +26,17 @@ define(['mout/object/max'], function(max){
 
         });
 
-    });
 
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            expect( max(obj, 'id') ).toEqual( obj.b  );
+            expect( max(obj, 'amet') ).toBeUndefined();
+        });
+
+
+    });
 });

--- a/tests/spec/object/spec-min.js
+++ b/tests/spec/object/spec-min.js
@@ -26,6 +26,17 @@ define(['mout/object/min'], function(min){
 
         });
 
-    });
 
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            expect( min(obj, 'id') ).toEqual( obj.c  );
+            expect( min(obj, 'amet') ).toBeUndefined();
+        });
+
+
+    });
 });

--- a/tests/spec/object/spec-reject.js
+++ b/tests/spec/object/spec-reject.js
@@ -23,6 +23,30 @@ define(['mout/object/reject', 'mout/object/size'], function(reject, size) {
             expect(result).toEqual({});
         });
 
-    });
 
+        it('should support shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            expect( reject(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( {} );
+            expect( reject(obj, {lorem:'ipsum', id:1}) ).toEqual( {b:obj.b, c:obj.c} );
+            expect( reject(obj, {amet:123}) ).toEqual( obj );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:0}
+            };
+            expect( reject(obj, 'foo') ).toEqual( {} );
+            expect( reject(obj, 'id') ).toEqual( {c:obj.c} );
+            expect( reject(obj, 'amet') ).toEqual( obj );
+        });
+
+
+    });
 });

--- a/tests/spec/object/spec-some.js
+++ b/tests/spec/object/spec-some.js
@@ -27,6 +27,32 @@ define(['mout/object/some'], function(some){
             expect( some(a2, isEven) ).toBe( false );
         });
 
-    });
 
+        it('should support shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1},
+                b : {foo:'bar', lorem:'ipsum', id:2},
+                c : {foo:'bar', lorem:'ipsum', id:4}
+            };
+            expect( some(obj, {foo:'bar', lorem:'ipsum'}) ).toEqual( true );
+            expect( some(obj, {lorem:'ipsum', id:1}) ).toEqual( true );
+            expect( some(obj, {id:123}) ).toEqual( false );
+            expect( some(obj, {amet:123}) ).toEqual( false );
+        });
+
+
+        it('should allow string shorthand syntax', function () {
+            var obj = {
+                a : {foo:'bar', lorem:'ipsum', id:1, disabled:false},
+                b : {foo:'bar', lorem:'ipsum', id:2, disabled:false},
+                c : {foo:'bar', lorem:'ipsum', id:0, disabled:false}
+            };
+            expect( some(obj, 'foo') ).toEqual( true );
+            expect( some(obj, 'id') ).toEqual( true );
+            expect( some(obj, 'amet') ).toEqual( false );
+            expect( some(obj, 'disabled') ).toEqual( false );
+        });
+
+
+    });
 });


### PR DESCRIPTION
had to change the `object/every` structure to avoid circular dependencies and
on most collections methods it was just a matter of adding tests to confirm
behavior and avoid regressions in the future.

also _improved_ `object/every` to make it consider any _falsy_ value as
a "failure" so now behavior matches `array/every` and string shorthand syntax
can be used to check against any _falsy_ values and property existence.

see #15
