### PR TITLE
add lang/is and lang/isnt

### DIFF
--- a/doc/lang.md
+++ b/doc/lang.md
@@ -157,6 +157,42 @@ myObj.getName(); // "lorem ipsum"
 ```
 
 
+## is(x, y):Boolean
+
+Check if both values are identical/egal.
+
+```js
+// wtfjs
+NaN === NaN; // false
+-0 === +0;   // true
+
+is(NaN, NaN); // true
+is(-0, +0);   // false
+is('a', 'b'); // false
+```
+
+See: [`isnt()`](#isnt)
+
+
+
+## isnt(x, y):Boolean
+
+Check if both values are not identical/egal.
+
+```js
+// wtfjs
+NaN === NaN; // false
+-0 === +0;   // true
+
+isnt(NaN, NaN); // false
+isnt(-0, +0);   // true
+isnt('a', 'b'); // true
+```
+
+See: [`is()`](#is)
+
+
+
 
 ## isArguments(val):Boolean
 

--- a/src/lang.js
+++ b/src/lang.js
@@ -9,6 +9,7 @@ return {
     'deepClone' : require('./lang/deepClone'),
     'defaults' : require('./lang/defaults'),
     'inheritPrototype' : require('./lang/inheritPrototype'),
+    'is' : require('./lang/is'),
     'isArguments' : require('./lang/isArguments'),
     'isArray' : require('./lang/isArray'),
     'isBoolean' : require('./lang/isBoolean'),
@@ -25,6 +26,7 @@ return {
     'isRegExp' : require('./lang/isRegExp'),
     'isString' : require('./lang/isString'),
     'isUndefined' : require('./lang/isUndefined'),
+    'isnt' : require('./lang/isnt'),
     'kindOf' : require('./lang/kindOf'),
     'toArray' : require('./lang/toArray'),
     'toString' : require('./lang/toString')

--- a/src/lang/is.js
+++ b/src/lang/is.js
@@ -1,0 +1,23 @@
+define(function () {
+
+    /**
+     * Check if both arguments are egal.
+     */
+    function is(x, y){
+        // implementation borrowed from harmony:egal spec
+        if (x === y) {
+          // 0 === -0, but they are not identical
+          return x !== 0 || 1 / x === 1 / y;
+        }
+
+        // NaN !== NaN, but they are identical.
+        // NaNs are the only non-reflexive value, i.e., if x !== x,
+        // then x is a NaN.
+        // isNaN is broken: it converts its argument to number, so
+        // isNaN("foo") => true
+        return x !== x && y !== y;
+    }
+
+    return is;
+
+});

--- a/src/lang/isnt.js
+++ b/src/lang/isnt.js
@@ -1,0 +1,12 @@
+define(['./is'], function (is) {
+
+    /**
+     * Check if both values are not identical/egal
+     */
+    function isnt(x, y){
+        return !is(x, y);
+    }
+
+    return isnt;
+
+});

--- a/tests/spec/lang/spec-is.js
+++ b/tests/spec/lang/spec-is.js
@@ -1,0 +1,34 @@
+define(['mout/lang/is'], function(is){
+
+    describe('lang/is', function(){
+
+        it('should return false if arguments are not identical', function(){
+            expect( is(true, false) ).toBe(false);
+            expect( is(1, true) ).toBe(false);
+            expect( is(1, 0) ).toBe(false);
+            expect( is(-0, +0) ).toBe(false); // yes, they are not identical
+            expect( is('a', 'b') ).toBe(false);
+            expect( is({}, {}) ).toBe(false);
+            expect( is([], []) ).toBe(false);
+            expect( is(NaN, 'NaN') ).toBe(false);
+            expect( is(Infinity, -Infinity) ).toBe(false);
+        });
+
+
+        it('should return true if arguments are identical', function(){
+            expect( is(true, true) ).toBe(true);
+            expect( is(1, 1) ).toBe(true);
+            expect( is(0, 0) ).toBe(true);
+            expect( is('a', 'a') ).toBe(true);
+            var obj = {};
+            expect( is(obj, obj) ).toBe(true);
+            var arr = [];
+            expect( is(arr, arr) ).toBe(true);
+            expect( is(NaN, NaN) ).toBe(true);
+            expect( is(Infinity, Infinity) ).toBe(true);
+        });
+
+
+    });
+
+});

--- a/tests/spec/lang/spec-isnt.js
+++ b/tests/spec/lang/spec-isnt.js
@@ -1,0 +1,33 @@
+define(['mout/lang/isnt'], function(isnt){
+
+    describe('lang/isnt', function(){
+
+        it('should return true if arguments are not identical', function(){
+            expect( isnt(true, false) ).toBe(true);
+            expect( isnt(1, true) ).toBe(true);
+            expect( isnt(1, 0) ).toBe(true);
+            expect( isnt(-0, +0) ).toBe(true); // yes, they are not identical
+            expect( isnt('a', 'b') ).toBe(true);
+            expect( isnt({}, {}) ).toBe(true);
+            expect( isnt([], []) ).toBe(true);
+            expect( isnt(NaN, 'NaN') ).toBe(true);
+            expect( isnt(Infinity, -Infinity) ).toBe(true);
+        });
+
+
+        it('should return false if arguments are identical', function(){
+            expect( isnt(true, true) ).toBe(false);
+            expect( isnt(1, 1) ).toBe(false);
+            expect( isnt(0, 0) ).toBe(false);
+            expect( isnt('a', 'a') ).toBe(false);
+            var obj = {};
+            expect( isnt(obj, obj) ).toBe(false);
+            var arr = [];
+            expect( isnt(arr, arr) ).toBe(false);
+            expect( isnt(NaN, NaN) ).toBe(false);
+            expect( isnt(Infinity, Infinity) ).toBe(false);
+        });
+
+    });
+
+});

--- a/tests/spec/spec-lang.js
+++ b/tests/spec/spec-lang.js
@@ -7,6 +7,7 @@ define([
     'lang/spec-deepClone',
     'lang/spec-defaults',
     'lang/spec-inheritPrototype',
+    'lang/spec-is',
     'lang/spec-isArguments',
     'lang/spec-isArray',
     'lang/spec-isBoolean',
@@ -23,6 +24,7 @@ define([
     'lang/spec-isRegExp',
     'lang/spec-isString',
     'lang/spec-isUndefined',
+    'lang/spec-isnt',
     'lang/spec-kindOf',
     'lang/spec-toArray',
     'lang/spec-toString'


### PR DESCRIPTION
Harmony have a proposal for the `is` and `isnt` operators and also for
`Object.is()` and `Object.isnt()`.

see: http://wiki.ecmascript.org/doku.php?id=harmony:egal
