### PR TITLE
improve number/sign behavior when value is NaN or +0 or -0

### DIFF
--- a/src/number/sign.js
+++ b/src/number/sign.js
@@ -4,9 +4,10 @@ define(function () {
      * Get sign of the value.
      */
     function sign(val) {
-        if (val === 0) return 0;
-        if (isNaN(val)) return NaN; // NaN
-        return val < 0? -1 : 1;
+        var num = Number(val);
+        if (num === 0) return num; // +0 and +0 === 0
+        if (isNaN(num)) return num; // NaN
+        return num < 0? -1 : 1;
     }
 
     return sign;

--- a/tests/spec/number/spec-sign.js
+++ b/tests/spec/number/spec-sign.js
@@ -18,12 +18,29 @@ define(['mout/number/sign'], function (sign) {
             expect( sign(0) ).toEqual(0);
         });
 
+        it('should return +0 if number is +0', function () {
+            expect( 1 / sign(+0) ).toBe( Infinity );
+        });
+
+        it('should return -0 if number is -0', function () {
+            expect( 1 / sign(-0) ).toBe( -Infinity );
+        });
+
         it('should return NaN if value is NaN', function () {
             expect( sign(NaN) ).toBeNaN();
         });
 
         it('should return NaN if value is not a Number', function () {
             expect( sign('foo') ).toBeNaN();
+        });
+
+        it('should typecast value into a number', function () {
+            expect( sign('-123') ).toEqual( -1 );
+            expect( sign('123') ).toEqual( 1 );
+            expect( sign('') ).toEqual( 0 );
+            expect( sign([]) ).toEqual( 0 );
+            expect( sign([1]) ).toEqual( 1 );
+            expect( sign(null) ).toEqual( 0 );
         });
 
     });


### PR DESCRIPTION
after merging PR #36 I realized we should also check if value `isNaN`.
