### PR TITLE
fix string/replace spec on IE7 and rename 3rd argument to replacements

### DIFF
--- a/doc/string.md
+++ b/doc/string.md
@@ -301,15 +301,15 @@ repeat('a', 0);  // ""
 
 
 
-## replace(str, search, replace):String
+## replace(str, search, replacements):String
 
 Replace string(s) with the replacement(s) in the source.
 
-`search` and `replace` can be an array, or a single item. For every item in
-`search`, it will call `str.replace` with the search item and the matching
-replacement in `replace`. If `replace` only contains one replacement, it will
-be used for all the searches, otherwise it will use the replacement at the same
-index as the search.
+`search` and `replacements` can be an array, or a single item. For every item
+in `search`, it will call `str.replace` with the search item and the matching
+replacement in `replacements`. If `replacements` only contains one replacement,
+it will be used for all the searches, otherwise it will use the replacement at
+the same index as the search.
 
 ### Example
 

--- a/src/string/replace.js
+++ b/src/string/replace.js
@@ -3,15 +3,15 @@ define(['../lang/toString', '../lang/toArray'], function (toString, toArray) {
     /**
      * Replace string(s) with the replacement(s) in the source.
      */
-    function replace(str, search, replace) {
+    function replace(str, search, replacements) {
         str = toString(str);
         search = toArray(search);
-        replace = toArray(replace);
+        replacements = toArray(replacements);
 
         var searchLength = search.length,
-            replaceLength = replace.length;
+            replacementsLength = replacements.length;
 
-        if (replaceLength !== 1 && searchLength !== replace.length) {
+        if (replacementsLength !== 1 && searchLength !== replacementsLength) {
             throw new Error('Unequal number of searches and replacements');
         }
 
@@ -21,7 +21,7 @@ define(['../lang/toString', '../lang/toArray'], function (toString, toArray) {
             // replacement is provided
             str = str.replace(
                 search[i],
-                replace[(replaceLength === 1) ? 0 : i]);
+                replacements[(replacementsLength === 1) ? 0 : i]);
         }
 
         return str;

--- a/tests/spec/string/spec-replace.js
+++ b/tests/spec/string/spec-replace.js
@@ -24,10 +24,10 @@ define(['mout/string/replace'], function(replace){
 
         it('should replace with function replacer', function(){
             function replaceNum(m) {
-                return (+m[0]) * (+m[0]);
+                return (+m) * (+m);
             }
             function replaceLetter(m) {
-                return m[0].charCodeAt(0);
+                return m.charCodeAt(0);
             }
 
             var result = replace('1 2 3 a', [/\d+/g, /[a-z]/g],


### PR DESCRIPTION
spec was failing on IE7 because strings chars can't be accessed with `[0]`
notation. Also renamed 3rd argument to `replacements` to make it different from
the function name (jshint stops complaining and easier to understand).
