### PR TITLE
Remove array duck-typing in object/deepMatches

### DIFF
--- a/src/object/deepMatches.js
+++ b/src/object/deepMatches.js
@@ -1,4 +1,4 @@
-define(['./forOwn'], function(forOwn) {
+define(['./forOwn', '../lang/isArray'], function(forOwn, isArray) {
 
     function containsMatch(array, pattern) {
         var i = -1, length = array.length;
@@ -39,8 +39,7 @@ define(['./forOwn'], function(forOwn) {
      */
     function deepMatches(target, pattern){
         if (target && typeof target === 'object') {
-            if (typeof target.length === 'number'
-                && typeof pattern.length === 'number') {
+            if (isArray(target) && isArray(pattern)) {
                 return matchArray(target, pattern);
             } else {
                 return matchObject(target, pattern);

--- a/tests/spec/object/spec-deepMatches.js
+++ b/tests/spec/object/spec-deepMatches.js
@@ -51,6 +51,16 @@ define(['mout/object/deepMatches'], function(deepMatches){
             expect( deepMatches(obj, { a: [ { c: ['b', 'd'] } ] }) ).toBe(false);
         });
 
+        it('should not duck-type arrays', function(){
+            var obj = { a: [0, 2, 3] };
+            expect( deepMatches(obj, { a: { length: 1, "0": 0 } }) ).toBe(false);
+        });
+
+        it('should match array properties with object', function(){
+            var obj = { a: [1, 2] };
+            expect( deepMatches(obj, { a: { length: 2 } }) ).toBe(true);
+        });
+
     });
 
 });


### PR DESCRIPTION
See https://github.com/mout/mout/commit/e030c2fccb035181991977a84df7ebd64b8a9a8e#commitcomment-2723761

This removes the check for `.length` in favor of using `lang/isArray`.

One interesting problem that I ran into was that I could not test for this behavior using an object in the target and an array in the pattern. With the new behavior it would match, since `.length` is not enumerable, and so it would only check to see that `obj["0"]` is the same.

/cc @millermedeiros @jdalton
