### PR TITLE
Added an elapsed time counter utility

### DIFF
--- a/src/date/elapsed.js
+++ b/src/date/elapsed.js
@@ -1,0 +1,36 @@
+define(['./totalDaysInMonth'], function (totalDaysInMonth) {
+
+	/**
+     * returns the total years, months and days since the given Date
+     */
+	function elapsed(since) {
+		var now 	= new Date();
+		var years	= now.getFullYear() - since.getFullYear();
+		var months	= now.getMonth() - since.getMonth();
+		var days	= now.getDate() - since.getDate();
+		var hours	= now.getHours() - since.getHours();
+
+		if (months < 0) {
+			years -= 1;
+			months += 12;
+		}
+
+		if (days < 0) {
+			months -= 1;
+			days += totalDaysInMonth(now.getFullYear(), now.getMonth());
+		}
+
+		if (hours < 0) {
+			days -= 1;
+			hours += 24;
+		}
+
+		return {
+			years: years,
+			months: months,
+			days: days
+		};
+	}
+
+	return elapsed;
+});

--- a/tests/spec/date/spec-elapsed.js
+++ b/tests/spec/date/spec-elapsed.js
@@ -1,0 +1,25 @@
+define(['mout/date/elapsed'], function(elapsed){
+
+    describe('date/elapsed', function(){
+
+        /**
+        * Today is April 4, 2013.
+        */
+
+        it('should return a object containing the total years, months and days elapsed ', function () {
+            expect( elapsed(new Date(1991, 6, 18)) ).toEqual({
+                years: 21,  // 2013 - 1991 - 1* (*because we're in april yet)
+                months: 8,  // 18/07 - 04/04 = 8 full months (ago, set, out, nov, dez, jan, fev, mar)
+                days: 16    // 18 - 4 (today), to complete a month at april
+            });
+        });
+
+        it('should be underage', function () {
+            expect( elapsed(new Date(1995, 4)).years ).toBeLessThan( 18 );
+        });
+
+        it('should have a beer', function () {
+            expect( elapsed(new Date(1995, 3, 4)).years ).toBeGreaterThan( 17 );
+        });
+    });
+});


### PR DESCRIPTION
Returns the total years, months and days since the given Date object.
Useful to check if user is of age, for example.

It not returns hours, minutes and seconds, because it can already be done using simple date comparison and `time/parseMs`.

This is my first contribution to an open-source project, so sorry about mistakes.
