### PR TITLE
object.get(obj: Object, prop: [String] U String): any

### DIFF
--- a/src/object/get.js
+++ b/src/object/get.js
@@ -4,12 +4,15 @@ define(function () {
      * get "nested" object property
      */
     function get(obj, prop){
-        var parts = prop.split('.'),
-            last = parts.pop();
+        var parts = (typeof prop === "string" ? prop.split('.') : prop);
+
+        if (parts.length === 0) return obj;
+
+        var last = parts.pop();
 
         while (prop = parts.shift()) {
             obj = obj[prop];
-            if (typeof obj !== 'object') return;
+            if (typeof obj !== 'object') return undefined;
         }
 
         return obj[last];

--- a/tests/spec/object/spec-get.js
+++ b/tests/spec/object/spec-get.js
@@ -1,6 +1,6 @@
 define(
     [
-        'mout/object/get'
+    'mout/object/get'
     ],
     function (get) {
 
@@ -27,8 +27,29 @@ define(
                 expect( get(foo, 'bar.dolor') ).toBe( undef );
             });
 
-        });
+            it('should accept arrays', function () {
+                var foo = {
+                    bar : {
+                        spam : 'eggs'
+                    }
+                };
 
+                expect(get(foo, ['bar', 'spam'])).toBe('eggs');
+            });
+
+            it('should return the original object when given an empty query', function () {
+                var anObject = {value: true};
+
+                expect(get(anObject, [])).toBe(anObject);
+            });
+
+            it('should return non-truthy results for the last value.', function () {
+                var anObject = {value: false};
+
+                expect(get(anObject, "value")).toBe(false);
+            });
+
+        });
     }
 );
 


### PR DESCRIPTION
object.get accepts an array of strings for its property argument, 
in addition to its string argument. IMO, the string version is less
generic.

I also made it so that passing an empty string/array would return the
initial object.

Personally, I called this function drill in my code, not get.

And just because it was a missing test, I tested for a non-truthy value as
the return value of the function.
