### PR TITLE
add object/functions and object/bindAll

### DIFF
--- a/doc/function.md
+++ b/doc/function.md
@@ -14,7 +14,7 @@ Return a function that will execute in the given context, optionally adding any 
  2. `context` (Object) : Execution context (object used as `this`)
  3. `[...args]` (*)    : Arguments (0...n arguments)
 
-See: [`partial()`](#partial)
+See: [`partial()`](#partial), [object/bindAll](./object.html#bindAll)
 
 
 

--- a/doc/object.md
+++ b/doc/object.md
@@ -4,6 +4,36 @@ Object utilities.
 
 
 
+## bindAll(obj, [...methodNames]):void
+
+Bind methods of the target object to always execute on its own context
+(ovewritting the original function).
+
+See: [function/bind](./function.html#bind)
+
+```js
+var view = {
+    name: 'Lorem Ipsum',
+    logNameOnClick: function() {
+        console.log(this.name);
+    }
+};
+
+// binds all methods by default
+bindAll(view);
+jQuery('#docs').on('click', view.logNameOnClick);
+```
+
+You can also specify the list of methods that you want to bind (in case you
+just want to bind a few of them).
+
+```js
+// only the listed methods will be bound to `obj` context
+bindAll(obj, 'logNameOnClick', 'doAwesomeStuffOnDrag');
+```
+
+
+
 ## contains(obj, value):Boolean
 
 Similar to [Array/contains](array.html#contains). Checks if Object contains
@@ -323,6 +353,21 @@ forOwn(obj, function(val, key, o){
 
 console.log(result); // 3
 console.log(keys);   // ['foo', 'bar']
+```
+
+
+
+## functions(obj):Array
+
+Returns a sorted list of all enumerable properties that have function values
+(including inherited properties).
+
+```js
+var obj = {
+    foo : function(){},
+    bar : 'baz'
+};
+functions(obj); // ['foo']
 ```
 
 

--- a/src/object.js
+++ b/src/object.js
@@ -3,6 +3,7 @@ define(function(require){
 //automatically generated, do not edit!
 //run `node build` instead
 return {
+    'bindAll' : require('./object/bindAll'),
     'contains' : require('./object/contains'),
     'deepEquals' : require('./object/deepEquals'),
     'deepFillIn' : require('./object/deepFillIn'),
@@ -15,6 +16,7 @@ return {
     'find' : require('./object/find'),
     'forIn' : require('./object/forIn'),
     'forOwn' : require('./object/forOwn'),
+    'functions' : require('./object/functions'),
     'get' : require('./object/get'),
     'has' : require('./object/has'),
     'hasOwn' : require('./object/hasOwn'),

--- a/src/object/bindAll.js
+++ b/src/object/bindAll.js
@@ -1,0 +1,16 @@
+define(['./functions', '../function/bind', '../array/forEach'], function (functions, bind, forEach) {
+
+    /**
+     * Binds methods of the object to be run in it's own context.
+     */
+    function bindAll(obj, rest_methodNames){
+        var keys = arguments.length > 1?
+                    Array.prototype.slice.call(arguments, 1) : functions(obj);
+        forEach(keys, function(key){
+            obj[key] = bind(obj[key], obj);
+        });
+    }
+
+    return bindAll;
+
+});

--- a/src/object/functions.js
+++ b/src/object/functions.js
@@ -1,0 +1,18 @@
+define(['./forIn'], function (forIn) {
+
+    /**
+     * return a list of all enumerable properties that have function values
+     */
+    function functions(obj){
+        var keys = [];
+        forIn(obj, function(val, key){
+            if (typeof val === 'function'){
+                keys.push(key);
+            }
+        });
+        return keys.sort();
+    }
+
+    return functions;
+
+});

--- a/tests/spec/object/spec-bindAll.js
+++ b/tests/spec/object/spec-bindAll.js
@@ -1,0 +1,54 @@
+define(['mout/object/bindAll'], function(bindAll){
+
+    describe('object/bindAll', function(){
+
+        it('should bind all methods by default', function(){
+            var obj = {
+                foo : 'bar',
+                a : function(){
+                    return this.foo;
+                },
+                bar : 'baz',
+                b : function(){
+                    return this.bar;
+                },
+                lorem : 'ipsum',
+                c : function(){
+                    return this.lorem;
+                }
+            };
+
+            bindAll(obj);
+
+            expect( obj.a.call(null) ).toBe( 'bar' );
+            expect( obj.b.call(this) ).toBe( 'baz' );
+            expect( obj.c.call(this) ).toBe( 'ipsum' );
+        });
+
+
+        it('should allow binding just a few methods', function(){
+            var obj = {
+                foo : 'bar',
+                a : function(){
+                    return this.foo;
+                },
+                bar : 'baz',
+                b : function(){
+                    return this.bar;
+                },
+                lorem : 'ipsum',
+                c : function(){
+                    return this.lorem;
+                }
+            };
+
+            bindAll(obj, 'a', 'c');
+
+            expect( obj.a.call(null) ).toBe( 'bar' );
+            expect( obj.b.call(this) ).toBeUndefined();
+            expect( obj.c.call(this) ).toBe( 'ipsum' );
+        });
+
+    });
+
+});

--- a/tests/spec/object/spec-functions.js
+++ b/tests/spec/object/spec-functions.js
@@ -1,0 +1,23 @@
+define(['mout/object/functions'], function(functions){
+
+    describe('object/functions', function(){
+
+        it('should return a sorted list of all enumerable properties that have function values', function(){
+            function Foo(){
+                this.a = 123;
+                this.b = 'qwe';
+                this.amet = function(){};
+            }
+            Foo.prototype.lorem = function(){};
+            Foo.prototype.dolor = function(){};
+            expect( functions( new Foo() ) ).toEqual( ['amet', 'dolor', 'lorem'] );
+        });
+
+
+        it('should return an empty array if no functions found', function () {
+            expect( functions({a:123, b:'123', c:[1], d:{e:'123'}}) ).toEqual([]);
+        });
+
+    });
+
+});

--- a/tests/spec/spec-object.js
+++ b/tests/spec/spec-object.js
@@ -1,6 +1,7 @@
 //automatically generated, do not edit!
 //run `node build` instead
 define([
+    './object/spec-bindAll',
     './object/spec-contains',
     './object/spec-deepEquals',
     './object/spec-deepFillIn',
@@ -13,6 +14,7 @@ define([
     './object/spec-find',
     './object/spec-forIn',
     './object/spec-forOwn',
+    './object/spec-functions',
     './object/spec-get',
     './object/spec-has',
     './object/spec-hasOwn',


### PR DESCRIPTION
I'm kinda tired of doing:

``` js
this._pickDateOnClick = bind(this._pickDateOnClick, this);
this._openOnEvent = bind(this._openOnEvent, this);
this._closeOnEvent = bind(this._closeOnEvent, this);
this._scrollNextOnEvent = bind(this._scrollNextOnEvent, this);
this._scrollPrevOnEvent = bind(this._scrollPrevOnEvent, this);
```

to be able to attach listeners to mouse/keyboard events. This would be clearer/simpler:

``` js
bindAll(this, '_pickDateOnClick', '_openOnEvent', '_closeOnEvent',
    '_scrollNextOnEvent', '_scrollPrevOnEvent');
```
