### PR TITLE
remove `create()` from number/currencyFormat

### DIFF
--- a/doc/number.md
+++ b/doc/number.md
@@ -49,14 +49,6 @@ Format a number as currency.
     currencyFormat(1000, 1);           // "1,000.0"
     currencyFormat(1000, 2, ',', '.'); // "1.000,00"
 
-You can also create a new instance that will have different defaults.
-
-    var cur = currencyFormat.create(0, ',', '.');
-    cur(1000);    // "1.000"
-    cur(1000, 1); // "1.000,0"
-    cur(1000, 2); // "1.000,00"
-
-PS: All arguments are required on the `currencyFormat.create()` method.
 
 
 ## enforcePrecision(val, nDecimalDigits):Number

--- a/src/number/currencyFormat.js
+++ b/src/number/currencyFormat.js
@@ -3,37 +3,24 @@ define(function () {
     /**
      * Converts number into currency format
      */
-    var currencyFormatter = {
+    function currencyFormat(val, nDecimalDigits, decimalSeparator, thousandsSeparator) {
+        nDecimalDigits = nDecimalDigits == null? 2 : nDecimalDigits;
+        decimalSeparator = decimalSeparator == null? '.' : decimalSeparator;
+        thousandsSeparator = thousandsSeparator == null? ',' : thousandsSeparator;
 
-        create : function($nDecimalDigits, $decimalSeparator, $thousandsSeparator){
+        //can't use enforce precision since it returns a number and we are
+        //doing a RegExp over the string
+        var fixed = val.toFixed(nDecimalDigits),
+            //separate begin [$1], middle [$2] and decimal digits [$4]
+            parts = new RegExp('^(-?\\d{1,3})((?:\\d{3})+)(\\.(\\d{'+ nDecimalDigits +'}))?$').exec( fixed );
 
-            var format = function (val, nDecimalDigits, decimalSeparator, thousandsSeparator) {
-                //defaults will be bound inside the closure, only way to replace
-                //them is by creating a new instance (avoids undesired side-effect)
-                nDecimalDigits = nDecimalDigits == null? $nDecimalDigits : nDecimalDigits;
-                decimalSeparator = decimalSeparator == null? $decimalSeparator : decimalSeparator;
-                thousandsSeparator = thousandsSeparator == null? $thousandsSeparator : thousandsSeparator;
-
-                //can't use enforce precision since it returns a number and we are
-                //doing a RegExp over the string
-                var fixed = val.toFixed(nDecimalDigits),
-                    //separate begin [$1], middle [$2] and decimal digits [$4]
-                    parts = new RegExp('^(-?\\d{1,3})((?:\\d{3})+)(\\.(\\d{'+ nDecimalDigits +'}))?$').exec( fixed );
-
-                if(parts){ //val >= 1000 || val <= -1000
-                    return parts[1] + parts[2].replace(/\d{3}/g, thousandsSeparator + '$&') + (parts[4] ? decimalSeparator + parts[4] : '');
-                }else{
-                    return fixed.replace('.', decimalSeparator);
-                }
-            };
-
-            //inception
-            format.create = currencyFormatter.create;
-
-            return format;
+        if(parts){ //val >= 1000 || val <= -1000
+            return parts[1] + parts[2].replace(/\d{3}/g, thousandsSeparator + '$&') + (parts[4] ? decimalSeparator + parts[4] : '');
+        }else{
+            return fixed.replace('.', decimalSeparator);
         }
-    };
+    }
 
-    return currencyFormatter.create(2, '.', ',');
+    return currencyFormat;
 
 });

--- a/tests/spec/number/spec-currencyFormat.js
+++ b/tests/spec/number/spec-currencyFormat.js
@@ -36,21 +36,4 @@ define(['mout/number/currencyFormat'], function (currencyFormat) {
 
     });
 
-    describe('number/currencyFormat.create()', function(){
-
-        it('should create a new instance with default arguments and they shouldn\'t interfer with each other', function () {
-            var brl = currencyFormat.create(2, ',', '.');
-            var cur = currencyFormat.create(0, '.', ',');
-
-            expect( brl(1.4) ).toEqual( '1,40' );
-            expect( brl(999.99) ).toEqual( '999,99' );
-            expect( brl(1234.56) ).toEqual( '1.234,56' );
-
-            expect( cur(1.4) ).toEqual( '1' );
-            expect( cur(999.99) ).toEqual( '1,000' );
-            expect( cur(1234.56) ).toEqual( '1,235' );
-        });
-
-    });
-
 });


### PR DESCRIPTION
decided to not implement `rpartial` since it is rarely needed and on most cases it is a bad practice.

closes #77
