### PR TITLE
Add Bower ignores

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,18 @@
 {
   "name": "mout",
   "version": "0.6.0",
-  "main": "src/"
+  "main": "src/",
+  "ignore": [
+    "_build",
+    "doc",
+    "tests",
+    ".editorconfig",
+    ".jshintrc",
+    ".npmignore",
+    ".travis.yml",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "build.js",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
Ignore all files that do not need to be installed. Makes for a much friendly Bower installation :)
