### PR TITLE
Add verification for arguments object on lang/toArray

### DIFF
--- a/src/lang/toArray.js
+++ b/src/lang/toArray.js
@@ -1,4 +1,4 @@
-define(['./kindOf'], function (kindOf) {
+define(['./kindOf', './isArguments'], function (kindOf, isArguments) {
 
     var _win = this;
 
@@ -11,6 +11,14 @@ define(['./kindOf'], function (kindOf) {
             n;
 
         if (val != null) {
+            if (isArguments(val)) {
+                // if the value given is an arguments object we just slice it
+                // and return the result, this should save some resources compared
+                // with an iteration, besides if a user is intentionally giving
+                // an arguments object, it most probably just want to avoid the
+                // pseudo-array gotchas
+                return Array.prototype.slice.call(val, 0);
+            }
             if ( val.length == null || kind === 'String' || kind === 'Function' || kind === 'RegExp' || val === _win ) {
                 //string, regexp, function have .length but user probably just want
                 //to wrap value into an array..


### PR DESCRIPTION
I believe most people passing an arguments object to `lang/toArray` just want
to get rid of the pseudo-array gotchas and convert it to an array.
To achieve that, using the Array.prototype.slice should be faster and save more
resources than iterating the object and create an array from scratch.
