### PR TITLE
Fix null value handling in object/get

### DIFF
--- a/src/object/get.js
+++ b/src/object/get.js
@@ -9,7 +9,7 @@ define(function () {
 
         while (prop = parts.shift()) {
             obj = obj[prop];
-            if (typeof obj !== 'object') return;
+            if (typeof obj !== 'object' || !obj) return;
         }
 
         return obj[last];

--- a/tests/spec/object/spec-get.js
+++ b/tests/spec/object/spec-get.js
@@ -27,6 +27,15 @@ define(
                 expect( get(foo, 'bar.dolor') ).toBe( undef );
             });
 
+            it('should return undefined when encountering null', function() {
+                var foo = {
+                    bar: null
+                };
+
+                var undef;
+                expect( get(foo, 'foo.bar.baz') ).toBe(undef);
+            });
+
         });
 
     }


### PR DESCRIPTION
Fixes #125. The bug is because `typeof null === "object"` in JS. It adds a test for the bug and fixes it with a check for a truthy value in addition to the `typeof object` test.
