### PR TITLE
improve function/throttle spec, change time/now to allow mocking it + improve mockRandom

### DIFF
--- a/src/function/throttle.js
+++ b/src/function/throttle.js
@@ -4,21 +4,19 @@ define(['../time/now'], function (now) {
      */
     function throttle(fn, delay){
         var context, timeout, result, args,
-            cur, diff, prev = 0;
+            diff, prevCall = 0;
         function delayed(){
-            prev = now();
+            prevCall = now();
             timeout = null;
             result = fn.apply(context, args);
         }
         function throttled(){
             context = this;
             args = arguments;
-            cur = now();
-            diff = delay - (cur - prev);
+            diff = delay - (now() - prevCall);
             if (diff <= 0) {
                 clearTimeout(timeout);
-                prev = cur;
-                result = fn.apply(context, args);
+                delayed();
             } else if (! timeout) {
                 timeout = setTimeout(delayed, diff);
             }

--- a/src/time/now.js
+++ b/src/time/now.js
@@ -3,7 +3,13 @@ define(function () {
     /**
      * Get current time in miliseconds
      */
-    var now = (typeof Date.now === 'function')? Date.now : function(){
+    function now(){
+        // yes, we defer the work to another function to allow mocking it
+        // during the tests
+        return now.get();
+    }
+
+    now.get = (typeof Date.now === 'function')? Date.now : function(){
         return +(new Date());
     };
 

--- a/tests/spec/array/spec-shuffle.js
+++ b/tests/spec/array/spec-shuffle.js
@@ -3,7 +3,7 @@ define(['mout/array/shuffle', '../random/helper-mockRandom'], function (shuffle,
     describe('array/shuffle()', function () {
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function() {

--- a/tests/spec/function/spec-debounce.js
+++ b/tests/spec/function/spec-debounce.js
@@ -1,9 +1,14 @@
-define(['mout/function/debounce'], function(debounce){
+define(['mout/function/debounce', '../time/helper-mockNow'], function(debounce, mockNow){
 
     describe('function/debounce', function(){
 
         beforeEach(function() {
             jasmine.Clock.useMock();
+            mockNow.start();
+        });
+
+        afterEach(function(){
+            mockNow.end();
         });
 
         it('should execute callback only once after consecutive calls and just after interval', function(){

--- a/tests/spec/function/spec-throttle.js
+++ b/tests/spec/function/spec-throttle.js
@@ -1,9 +1,15 @@
-define(['mout/function/throttle'], function(throttle){
+define(['mout/function/throttle', '../time/helper-mockNow'], function(throttle, mockNow){
 
     describe('function/throttle', function(){
 
+
         beforeEach(function() {
             jasmine.Clock.useMock();
+            mockNow.start();
+        });
+
+        afterEach(function(){
+            mockNow.end();
         });
 
         it('should execute callback only once per interval', function(){
@@ -14,22 +20,58 @@ define(['mout/function/throttle'], function(throttle){
             }, 50);
 
             expect(count).toEqual(0);
+            // ensure it was called once during interval
             while (++i <= 5) { cb(); }
             expect(count).toEqual(1);
 
-            jasmine.Clock.tick(51);
+            // ensure it was not called again before timeout
+            jasmine.Clock.tick(49);
+            expect(count).toEqual(1);
+
             // ensure it was called again after timeout
+            jasmine.Clock.tick(1);
             expect(count).toEqual(2);
 
+            // ensure it wasnt called more than once at tail
+            jasmine.Clock.tick(51);
+            expect(count).toEqual(2);
+
+            // ensure it still works after "delay gaps"
+            jasmine.Clock.tick(120);
+            expect(count).toEqual(2);
+            cb();
+            expect(count).toEqual(3);
+            jasmine.Clock.tick(1);
             i = 0;
             while (++i <= 5) { cb(); }
-            // ensure it wasn't called until timeout
-            expect(count).toEqual(2);
-
-            // ensure it is executed once at "tail" of callbacks
-            jasmine.Clock.tick(150);
             expect(count).toEqual(3);
+
+            // ensure it wasnt called during interval
+            jasmine.Clock.tick(48);
+            expect(count).toEqual(3);
+
+            // ensure it is called at tail
+            jasmine.Clock.tick(1);
+            expect(count).toEqual(4);
+
+            // only once at tail
+            jasmine.Clock.tick(51);
+            expect(count).toEqual(4);
         });
+
+
+        it('should not call again at tail if called just once', function () {
+            var count = 0;
+            var cb = throttle(function() {
+                count++;
+            }, 50);
+
+            cb();
+            expect(count).toEqual(1);
+            jasmine.Clock.tick(51);
+            expect(count).toEqual(1);
+        });
+
 
         it('should allow passing args and should use first supplied value by default', function () {
             var count = 0;

--- a/tests/spec/random/helper-mockRandom.js
+++ b/tests/spec/random/helper-mockRandom.js
@@ -1,27 +1,19 @@
-define(['mout/random/random'], function(random) {
-    var original;
+define(['exports', 'mout/random/random'], function(exports, random) {
+    var original = random.get;
 
     // Values to return from the mocked generator
     // The values should be equally split with no bias.
     var values = [0.1, 0.7, 0.3, 0.45, 0.55, 0.9, 0.2, 0.35, 0.8, 0.65];
 
-    function mockRandom() {
-        original = random.get;
-
+    exports.start = function() {
         var i = 0;
         random.get = function() {
             return values[i++ % values.length];
         };
-    }
-
-    mockRandom.end = function() {
-        if (!original) {
-            throw new Error('Invalid mockRandom.end()');
-        }
-
-        random.get = original;
-        original = null;
     };
 
-    return mockRandom;
+    exports.end = function() {
+        random.get = original;
+    };
+
 });

--- a/tests/spec/random/spec-choice.js
+++ b/tests/spec/random/spec-choice.js
@@ -3,7 +3,7 @@ define(['mout/random/choice', './helper-mockRandom'], function (choice, mockRand
     describe('random/choice()', function () {
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function() {

--- a/tests/spec/random/spec-guid.js
+++ b/tests/spec/random/spec-guid.js
@@ -3,7 +3,7 @@ define(['mout/random/guid', './helper-mockRandom'], function (guid, mockRandom) 
     describe('random/guid()', function(){
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function(){

--- a/tests/spec/random/spec-rand.js
+++ b/tests/spec/random/spec-rand.js
@@ -3,7 +3,7 @@ define(['mout/random/rand', './helper-mockRandom'], function (rand, mockRandom) 
     describe('random/rand()', function(){
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function() {

--- a/tests/spec/random/spec-randBit.js
+++ b/tests/spec/random/spec-randBit.js
@@ -3,7 +3,7 @@ define(['mout/random/randBit', './helper-mockRandom'], function (randBit, mockRa
     describe('random/randBit()', function(){
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function(){

--- a/tests/spec/random/spec-randHex.js
+++ b/tests/spec/random/spec-randHex.js
@@ -3,7 +3,7 @@ define(['mout/random/randHex', './helper-mockRandom'], function (randHex, mockRa
     describe('random/randHex()', function () {
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function() {

--- a/tests/spec/random/spec-randInt.js
+++ b/tests/spec/random/spec-randInt.js
@@ -3,7 +3,7 @@ define(['mout/random/randInt', './helper-mockRandom'], function (randInt, mockRa
     describe('random/randInt()', function(){
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function(){

--- a/tests/spec/random/spec-randSign.js
+++ b/tests/spec/random/spec-randSign.js
@@ -3,7 +3,7 @@ define(['mout/random/randSign', './helper-mockRandom'], function (randSign, mock
     describe('random/randSign()', function(){
 
         beforeEach(function(){
-            mockRandom();
+            mockRandom.start();
         });
 
         afterEach(function(){

--- a/tests/spec/time/helper-mockNow.js
+++ b/tests/spec/time/helper-mockNow.js
@@ -1,0 +1,25 @@
+define(['exports', 'mout/time/now'], function(exports, now) {
+
+    var time;
+    var original = now.get;
+    var interval;
+
+    exports.start = function (ts) {
+        time = ts != null? ts : 1382023145920;
+        now.get = function() {
+            return time;
+        };
+        interval = setInterval(function(){
+            time += 1;
+        }, 1);
+    };
+
+    exports.end = function() {
+        if (interval) {
+            clearInterval(interval);
+            interval = null;
+        }
+        now.get = original;
+    };
+
+});


### PR DESCRIPTION
@satazor said he was having issues with `function/throttle` not calling the function at the "tail" of the interval.

I added more tests and added a way to mock the `time/now` to make sure behaviour is consistent but I could not replicate any bugs - after mocking the `Date.now` to sync with the `jasmine.Clock` all tests passes...

Expected behavior:

```
||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
X    X    X    X    X    X        X    X    X    X    X    X
```

`|` is a throttled-function call and `X` is the actual `fn` execution:

Let me know if anyone have any idea on how to improve the tests.

PS: @satazor issue was with a window scroll handler, not sure if that is the cause of the issue (maybe the scroll event messes up with the `setTimeout` and `Date.now` - blocks the thread and somehow skips execution...)
