### PR TITLE
add number/ordinal & number/nth

### DIFF
--- a/doc/number.md
+++ b/doc/number.md
@@ -117,6 +117,39 @@ console.log( MIN_INT ); // -2147483648
 ```
 
 
+## nth(n):String
+
+Returns the "nth" of number. (`"st"`, `"nd"`, `"rd"`, `"th"`)
+
+```js
+nth(1); // "st"
+nth(2); // "nd"
+nth(12); // "th"
+nth(22); // "nd"
+nth(23); // "rd"
+nth(34); // "th"
+```
+
+See: [`ordinal()`](#ordinal)
+
+
+
+## ordinal(n):String
+
+Converts number into ordinal form (1st, 2nd, 3rd, 4th, ...)
+
+```js
+ordinal(1); // "1st"
+ordinal(2); // "2nd"
+ordinal(3); // "3rd"
+ordinal(14); // "14th"
+ordinal(21); // "21st"
+```
+
+See: [`nth()`](#nth)
+
+
+
 ## pad(n, minLength[, char]):String
 
 Add padding zeros if `n.length` < `minLength`.

--- a/src/number.js
+++ b/src/number.js
@@ -10,6 +10,8 @@ return {
     'currencyFormat' : require('./number/currencyFormat'),
     'enforcePrecision' : require('./number/enforcePrecision'),
     'isNaN' : require('./number/isNaN'),
+    'nth' : require('./number/nth'),
+    'ordinal' : require('./number/ordinal'),
     'pad' : require('./number/pad'),
     'rol' : require('./number/rol'),
     'ror' : require('./number/ror'),

--- a/src/number/nth.js
+++ b/src/number/nth.js
@@ -1,0 +1,25 @@
+define(function () {
+
+    /**
+     * Returns "nth" of number (1 = "st", 2 = "nd", 3 = "rd", 4..10 = "th", ...)
+     */
+    function nth(i) {
+        var t = (i % 100);
+        if (t >= 10 && t <= 20) {
+            return 'th';
+        }
+        switch(i % 10) {
+            case 1:
+                return 'st';
+            case 2:
+                return 'nd';
+            case 3:
+                return 'rd';
+            default:
+                return 'th';
+        }
+    }
+
+    return nth;
+
+});

--- a/src/number/ordinal.js
+++ b/src/number/ordinal.js
@@ -1,0 +1,13 @@
+define(['./toInt', './nth'], function (toInt, nth) {
+
+    /**
+     * converts number into ordinal form (1st, 2nd, 3rd, 4th, ...)
+     */
+    function ordinal(n){
+       n = toInt(n);
+       return n + nth(n);
+    }
+
+    return ordinal;
+
+});

--- a/tests/spec/number/spec-nth.js
+++ b/tests/spec/number/spec-nth.js
@@ -1,0 +1,78 @@
+define(['mout/number/nth'], function(nth){
+
+    describe('number/nth', function(){
+
+        it('should return "st" for numbers ending in "1" besides numbers that ends in "11"', function(){
+            expect( nth(1) ).toBe('st');
+            expect( nth(11) ).not.toBe('st');
+            expect( nth(21) ).toBe('st');
+            expect( nth(31) ).toBe('st');
+            expect( nth(51) ).toBe('st');
+            expect( nth(101) ).toBe('st');
+            expect( nth(111) ).not.toBe('st');
+            expect( nth(121) ).toBe('st');
+            expect( nth(1001) ).toBe('st');
+            expect( nth(1011) ).not.toBe('st');
+            expect( nth(1021) ).toBe('st');
+        });
+
+        it('should return "th" for numbers ending in "11"', function () {
+            expect( nth(11) ).toEqual('th');
+            expect( nth(111) ).toEqual('th');
+            expect( nth(211) ).toEqual('th');
+            expect( nth(1011) ).toEqual('th');
+        });
+
+        it('should return "nd" for numbers ending in "2" besides numbers that ends in "12"', function () {
+            expect( nth(2) ).toEqual('nd');
+            expect( nth(12) ).not.toEqual('nd');
+            expect( nth(22) ).toEqual('nd');
+            expect( nth(212) ).not.toEqual('nd');
+            expect( nth(232) ).toEqual('nd');
+            expect( nth(1012) ).not.toEqual('nd');
+            expect( nth(1052) ).toEqual('nd');
+        });
+
+        it('should return "th" for numbers ending in "12"', function () {
+            expect( nth(12) ).toEqual('th');
+            expect( nth(112) ).toEqual('th');
+            expect( nth(212) ).toEqual('th');
+            expect( nth(1012) ).toEqual('th');
+        });
+
+        it('should return "rd" for numbers ending in "3" besides numbers that ends in "13"', function () {
+            expect( nth(3) ).toEqual('rd');
+            expect( nth(13) ).not.toEqual('rd');
+            expect( nth(23) ).toEqual('rd');
+            expect( nth(233) ).toEqual('rd');
+            expect( nth(1013) ).not.toEqual('rd');
+            expect( nth(1053) ).toEqual('rd');
+        });
+
+        it('should return "th" for numbers ending in "13"', function () {
+            expect( nth(13) ).toEqual('th');
+            expect( nth(113) ).toEqual('th');
+            expect( nth(213) ).toEqual('th');
+            expect( nth(1013) ).toEqual('th');
+        });
+
+        it('should return "th" for numbers ending in "4, 5, 6, 7, 8, 9, 0', function () {
+            expect( nth(0) ).toEqual('th');
+            expect( nth(4) ).toEqual('th');
+            expect( nth(5) ).toEqual('th');
+            expect( nth(6) ).toEqual('th');
+            expect( nth(7) ).toEqual('th');
+            expect( nth(8) ).toEqual('th');
+            expect( nth(9) ).toEqual('th');
+            expect( nth(104) ).toEqual('th');
+            expect( nth(115) ).toEqual('th');
+            expect( nth(216) ).toEqual('th');
+            expect( nth(1017) ).toEqual('th');
+            expect( nth(2018) ).toEqual('th');
+            expect( nth(123019) ).toEqual('th');
+            expect( nth(9281230) ).toEqual('th');
+        });
+
+    });
+
+});

--- a/tests/spec/number/spec-ordinal.js
+++ b/tests/spec/number/spec-ordinal.js
@@ -1,0 +1,43 @@
+define(['mout/number/ordinal'], function(ordinal){
+
+    describe('number/ordinal', function(){
+
+        it('should return "[N]st" if number ends with "1" and [N]th if number ends with "11"', function(){
+            expect( ordinal(1) ).toBe('1st');
+            expect( ordinal(11) ).toBe('11th');
+            expect( ordinal(111) ).toBe('111th');
+            expect( ordinal(12341) ).toBe('12341st');
+        });
+
+        it('should return "[N]nd" dor numbers ending with "2" and [N]th for numbers that ends with "12"', function () {
+            expect( ordinal(2) ).toBe('2nd');
+            expect( ordinal(12) ).toBe('12th');
+            expect( ordinal(22) ).toBe('22nd');
+            expect( ordinal(2012) ).toBe('2012th');
+            expect( ordinal(12342) ).toBe('12342nd');
+        });
+
+        it('should return "[N]rd" if number ends with "3" and [N]th if number ends with "13"', function () {
+            expect( ordinal(3) ).toBe('3rd');
+            expect( ordinal(13) ).toBe('13th');
+            expect( ordinal(23) ).toBe('23rd');
+            expect( ordinal(1013) ).toBe('1013th');
+            expect( ordinal(12343) ).toBe('12343rd');
+        });
+
+        it('should return "[N]th" for numbers ended with 4,5,6,7,8,9,0', function () {
+            expect( ordinal(4) ).toBe('4th');
+            expect( ordinal(5) ).toBe('5th');
+            expect( ordinal(6) ).toBe('6th');
+            expect( ordinal(7) ).toBe('7th');
+            expect( ordinal(8) ).toBe('8th');
+            expect( ordinal(9) ).toBe('9th');
+            expect( ordinal(10) ).toBe('10th');
+            expect( ordinal(100) ).toBe('100th');
+            expect( ordinal(456) ).toBe('456th');
+            expect( ordinal(1459) ).toBe('1459th');
+        });
+
+    });
+
+});

--- a/tests/spec/spec-number.js
+++ b/tests/spec/spec-number.js
@@ -8,6 +8,8 @@ define([
     './number/spec-currencyFormat',
     './number/spec-enforcePrecision',
     './number/spec-isNaN',
+    './number/spec-nth',
+    './number/spec-ordinal',
     './number/spec-pad',
     './number/spec-rol',
     './number/spec-ror',


### PR DESCRIPTION
this can be useful in some cases, let's say you need to display a dynamic `1st`, `2nd`, `3rd` strings and maybe the _nth_ part of the string should be formatted in a different way, let's say 1<sup>st</sup>, 2<sup>nd</sup>, 3<sup>rd</sup>... that's why I decided to break into 2 separate modules.

this will also be useful for LDML date format (#102)
