### PR TITLE
Add array/sortBy

### DIFF
--- a/doc/array.md
+++ b/doc/array.md
@@ -715,6 +715,8 @@ the `compareFn`.
  - If `compareFn(a, b)` is greater than `0`, sort `b` to a lower index than
    `a`.
 
+See: [`sortBy`](#sortBy)
+
 ### Example
 
 ```js
@@ -733,6 +735,31 @@ sort([2, 3, 1, 4], function(a, b){
     // reverse sort
     return b - a;
 });
+```
+
+
+
+## sortBy(arr, callback, [context]):Array
+
+Returns an array sorted by the result of the callback.
+
+The callback is called for each item that is to be sorted, and the
+results of the callback are used to sort the array. The callback
+is called with the item as the first parameter, optionally with
+the provided context.
+
+It also supports a shorthand notation which can be used to sort by a property
+name.
+
+See: [`sort`](#sort)
+
+```js
+// Returns [{ a: 1 }, { a: 2 }, { a: 3 }]
+sortBy([{ a: 1 }, { a: 3 }, { a: 2 }],
+    function(item) { return item.a; });
+
+// Same as above, using shorthand notation
+sortBy([{ a: 1 }, { a: 3 }, { a: 2 }], 'a');
 ```
 
 

--- a/src/array.js
+++ b/src/array.js
@@ -37,6 +37,7 @@ return {
     'shuffle' : require('./array/shuffle'),
     'some' : require('./array/some'),
     'sort' : require('./array/sort'),
+    'sortBy' : require('./array/sortBy'),
     'split' : require('./array/split'),
     'toLookup' : require('./array/toLookup'),
     'union' : require('./array/union'),

--- a/src/array/sortBy.js
+++ b/src/array/sortBy.js
@@ -1,0 +1,18 @@
+define(['./sort', '../function/makeIterator_'], function (sort, makeIterator) {
+
+    /*
+     * Sort array by the result of the callback
+     */
+    function sortBy(arr, callback, context){
+        callback = makeIterator(callback, context);
+
+        return sort(arr, function(a, b) {
+            a = callback(a);
+            b = callback(b);
+            return (a < b) ? -1 : ((a > b) ? 1 : 0);
+        });
+    }
+
+    return sortBy;
+
+});

--- a/tests/spec/array/spec-sortBy.js
+++ b/tests/spec/array/spec-sortBy.js
@@ -1,0 +1,55 @@
+define(['mout/array/sortBy'], function(sortBy){
+
+    describe('array/sortBy', function(){
+
+        it('should sort array with function', function(){
+            var arr = [
+                { a: 1 },
+                { a: 3 },
+                { a: 2 }
+            ];
+
+            var result = sortBy(arr, function(item){ return item.a; });
+            expect(result).toEqual([ arr[0], arr[2], arr[1] ]);
+        });
+
+        it('should sort array with property name', function() {
+            var arr = [
+                { a: 3 },
+                { a: 5 },
+                { a: 1 }
+            ];
+
+            var result = sortBy(arr, 'a');
+            expect( sortBy(arr, 'a') ).toEqual([ arr[2], arr[0], arr[1] ]);
+        });
+
+        it('should pass index and context to accessor', function() {
+            var context = {},
+                arr = [
+                    { b: 'a' },
+                    { b: 'c' },
+                    { b: 'b' }
+                ];
+
+            var result = sortBy(arr, function(item) {
+                expect( this ).toBe(context);
+                return item.b;
+            }, context);
+
+            expect( result ).toEqual([ arr[0], arr[2], arr[1] ]);
+        });
+
+        it('should handle null array', function() {
+            var result = sortBy(null, function() { return 1; });
+            expect( result ).toEqual([]);
+        });
+
+        it('should handle empty array', function() {
+            var result = sortBy([], function() { return 1; });
+            expect( result ).toEqual([]);
+        });
+
+    });
+
+});

--- a/tests/spec/spec-array.js
+++ b/tests/spec/spec-array.js
@@ -35,6 +35,7 @@ define([
     './array/spec-shuffle',
     './array/spec-some',
     './array/spec-sort',
+    './array/spec-sortBy',
     './array/spec-split',
     './array/spec-toLookup',
     './array/spec-union',


### PR DESCRIPTION
Implementation for #144, adding `array/sortBy`.

One minor catch is that the callback is nearly the same as `array/map`, but it does not pass the index or source array to the callback (since `array/sort` does not provide this).
