### PR TITLE
Accept leading zeros for &#39 in unescapeHtml

### DIFF
--- a/src/string/unescapeHtml.js
+++ b/src/string/unescapeHtml.js
@@ -8,7 +8,7 @@ define(['../lang/toString'], function (toString) {
             .replace(/&amp;/g , '&')
             .replace(/&lt;/g  , '<')
             .replace(/&gt;/g  , '>')
-            .replace(/&#39;/g , "'")
+            .replace(/&#0*39;/g , "'")
             .replace(/&quot;/g, '"');
         return str;
     }

--- a/tests/spec/string/spec-unescapeHtml.js
+++ b/tests/spec/string/spec-unescapeHtml.js
@@ -2,9 +2,24 @@ define(['mout/string/unescapeHtml'], function (unescapeHtml) {
 
     describe('string/unescapeHtml()', function () {
 
-        it('should convert entities into chars', function () {
-            expect( unescapeHtml( '&lt;em&gt;&#39;lorem&#39;&lt;/em&gt; &amp; &quot;ipsum&quot;' ) )
-                .toEqual( '<em>\'lorem\'</em> & "ipsum"' );
+        it('should convert &amp;', function() {
+            expect( unescapeHtml('foo &amp; bar') ).toEqual( 'foo & bar' );
+        });
+
+        it('should convert &quot;', function() {
+            expect( unescapeHtml('&quot;foo&quot;') ).toEqual( '"foo"' );
+        });
+
+        it('should convert &gt; and &lt;', function() {
+            expect( unescapeHtml('&lt;foo&gt;') ).toEqual( '<foo>' );
+        });
+
+        it('should convert &#39;', function() {
+            expect( unescapeHtml('&#39;foo&#39;') ).toEqual( '\'foo\'' );
+        });
+
+        it('should accept leading zeros in &#39;', function() {
+            expect( unescapeHtml('&#0039;foo&#039;') ).toEqual( '\'foo\'' );
         });
 
         it('should return empty string if no argument', function () {


### PR DESCRIPTION
Fixes #151. Accepts any number of leading zeros for `&#39;`. This also
splits out the variuous escape sequences into a test for each one.
