### PR TITLE
Use custom array/slice implementation

### DIFF
--- a/src/array/slice.js
+++ b/src/array/slice.js
@@ -6,7 +6,19 @@ define(function () {
      * Create slice of source array or array-like object
      */
     function slice(arr, start, end){
-        return arrSlice.call(arr, start, end);
+        if (typeof start === 'undefined') {
+            start = 0;
+        }
+        if (typeof end === 'undefined') {
+            end = arr.length;
+        }
+
+        var result = [];
+        while (start < end) {
+            result.push(arr[start++]);
+        }
+
+        return result;
     }
 
     return slice;

--- a/tests/spec/array/spec-slice.js
+++ b/tests/spec/array/spec-slice.js
@@ -26,6 +26,21 @@ define(['mout/array/slice'], function(slice){
             expect( result.constructor ).toBe( Array );
         });
 
+        it('should convert NodeList objects', function() {
+            if (typeof document === 'undefined') {
+                expect(true).toBeTruthy('not in browser');
+                return;
+            }
+
+            // Native Array.prototype.slice errors in IE 8 on NodeList
+            var el = document.createElement('div'),
+                child = document.createElement('div');
+            el.appendChild(child);
+
+            var list = el.childNodes;
+            expect(slice(list)).toEqual([child]);
+        });
+
     });
 
 });


### PR DESCRIPTION
Fixes #159 

This fixes the issues with `NodeList` objects and optional arguments in IE8.
