### PR TITLE
return the prototype on inheritPrototype

### DIFF
--- a/doc/lang.md
+++ b/doc/lang.md
@@ -132,11 +132,13 @@ Return first value that isn't `null` or `undefined`.
 
 
 
-## inheritPrototype(childCtor, parentCtor):void
+## inheritPrototype(childCtor, parentCtor):Object
 
 Inherit the prototype methods from one constructor into another.
 
 Similar to [node.js util/inherits](http://nodejs.org/docs/latest/api/util.html#util_util_inherits_constructor_superconstructor).
+
+It returns the the `childCtor.prototype` for convenience.
 
 ```js
 function Foo(name){
@@ -152,7 +154,10 @@ function Bar(name){
     Foo.call(this, name);
 }
 //should be called before calling constructor
-inheritPrototype(Bar, Foo);
+var proto = inheritPrototype(Bar, Foo);
+
+// for convenience we return the new prototype object
+console.log(proto === Bar.prototype); // true
 
 var myObj = new Bar('lorem ipsum');
 myObj.getName(); // "lorem ipsum"

--- a/src/lang/inheritPrototype.js
+++ b/src/lang/inheritPrototype.js
@@ -11,6 +11,7 @@ define(['./createObject'], function(createObject){
         p.constructor = child;
         child.prototype = p;
         child.super_ = parent;
+        return p;
     }
 
     return inheritPrototype;

--- a/tests/spec/lang/spec-inheritPrototype.js
+++ b/tests/spec/lang/spec-inheritPrototype.js
@@ -2,23 +2,25 @@ define(['mout/lang/inheritPrototype'], function (inheritPrototype) {
 
     describe('lang/inheritPrototype()', function(){
 
-        it('should inherit prototype', function(){
+        var Foo, Bar;
 
-            function Foo(name){
+        beforeEach(function(){
+            Foo = function FooCtor(name){
                 this.name = name;
-            }
+            };
             Foo.prototype = {
                 getName : function(){
                     return this.name;
                 }
             };
-
-            function Bar(name){
+            Bar = function BarCtor(name){
                 this.name = name;
-            }
+            };
+        });
+
+        it('should inherit prototype', function(){
             inheritPrototype(Bar, Foo);
             Bar.prototype.test = true;
-
 
             var a = new Foo('ipsum');
             var b = new Bar('asd');
@@ -36,7 +38,11 @@ define(['mout/lang/inheritPrototype'], function (inheritPrototype) {
             expect(Bar.super_).toBe(Foo);
             expect(b instanceof Foo).toBe(true);
             expect(b instanceof Bar).toBe(true);
+        });
 
+        it('should return the prototype object', function(){
+            var proto = inheritPrototype(Bar, Foo);
+            expect(proto).toBe(Bar.prototype);
         });
 
     });


### PR DESCRIPTION
just for convenience and since it doesn't increase complexity.

closes #165
