### PR TITLE
fix array/slice behavior when start/end is higher than array length

### DIFF
--- a/src/array/slice.js
+++ b/src/array/slice.js
@@ -4,16 +4,22 @@ define(function () {
      * Create slice of source array or array-like object
      */
     function slice(arr, start, end){
+        var len = arr.length;
+
         if (start == null) {
             start = 0;
         } else if (start < 0) {
-            start = Math.max(arr.length + start, 0);
+            start = Math.max(len + start, 0);
+        } else {
+            start = Math.min(start, len);
         }
 
         if (end == null) {
-            end = arr.length;
+            end = len;
         } else if (end < 0) {
-            end = Math.max(arr.length + end, 0);
+            end = Math.max(len + end, 0);
+        } else {
+            end = Math.min(end, len);
         }
 
         var result = [];

--- a/tests/spec/array/spec-slice.js
+++ b/tests/spec/array/spec-slice.js
@@ -12,7 +12,7 @@ define(['mout/array/slice'], function(slice){
             expect( slice(arr, 1) ).toEqual( [2, 3, 4] );
         });
 
-        it('should include whole array when start omitted', function(){
+        it('should include whole array when start and end are omitted', function(){
             var arr = [1, 2, 3, 4],
                 result = slice(arr);
             expect( result ).toEqual( arr );
@@ -26,10 +26,27 @@ define(['mout/array/slice'], function(slice){
             expect( slice(arr, -2, -1) ).toEqual( [3] );
         });
 
-        it('should not allow negative start/end beyond array length', function() {
+        it('should clamp negative start/end beyond array length', function() {
             var arr = [1, 2, 3];
             expect( slice(arr, -5, 2) ).toEqual( [1, 2] );
             expect( slice(arr, 0, -5) ).toEqual( [] );
+        });
+
+        it('should return empty array if start/end is higher than array length', function() {
+            var arr = [1, 2, 3];
+            expect( slice(arr, 5) ).toEqual( [] );
+            expect( slice(arr, 5, 15) ).toEqual( [] );
+        });
+
+        it('should return whole array if end is higher than length', function() {
+            var arr = [1, 2, 3];
+            expect( slice(arr, 0, 8) ).toEqual( [1, 2, 3] );
+        });
+
+        it('should NOT skip sparse array indexes', function() {
+            var arr = [1];
+            arr[4] = 4;
+            expect( slice(arr, 3, 5) ).toEqual( [undefined, 4] );
         });
 
         it('should convert array-like object to array', function(){


### PR DESCRIPTION
I think we should release v0.9.1 as soon as this gets merged since it's a bug fix.

closes #170
