### PR TITLE
Fix findLastIndex to stop at zero index

### DIFF
--- a/src/array/findLastIndex.js
+++ b/src/array/findLastIndex.js
@@ -10,7 +10,7 @@ define(['../function/makeIterator_'], function (makeIterator) {
         }
 
         var n = arr.length;
-        while (n-- >= 0) {
+        while (--n >= 0) {
             if (iterator(arr[n], n, arr)) {
                 return n;
             }

--- a/tests/spec/array/spec-findLastIndex.js
+++ b/tests/spec/array/spec-findLastIndex.js
@@ -40,6 +40,21 @@ define(['mout/array/findLastIndex'], function(findLastIndex){
             expect( findLastIndex(undefined, testFunc) ).toBe( -1 );
         });
 
+        it('should pass array index and context', function() {
+            var items = [1, 2, 3];
+            var context = {};
+            var testFunc = function(val, i, arr) {
+                expect( this ).toBe( context );
+                expect( arr ).toBe( items );
+                expect( val ).toBe( arr[i] );
+                expect( i ).toBeGreaterThan( -1 );
+                expect( i ).toBeLessThan( items.length );
+                return false;
+            };
+
+            expect( findLastIndex(items, testFunc, context) ).toBe( -1 );
+        });
+
     });
 
 });


### PR DESCRIPTION
Before this fix, `array/findLastIndex` would iterate to the `-1` index, which of course is undefined in the array. This actually still passed the tests. I added more comprehensive tests to catch this and fixed `findLastIndex`.

This bug showed up when trying to filter on object properties, for example `findLastIndex([ { a: 1 } ], function(v) { return v.a === 1; });`, since it cannot get the `.a` property on undefined.
