### PR TITLE
get should return undefined on primitives.

### DIFF
--- a/src/object/get.js
+++ b/src/object/get.js
@@ -9,7 +9,7 @@ define(['../lang/isPrimitive'], function (isPrimitive) {
 
         while (prop = parts.shift()) {
             obj = obj[prop];
-            if (isPrimitive(obj) || !obj) return;
+            if (obj == null) return;
         }
 
         return obj[last];

--- a/tests/spec/object/spec-get.js
+++ b/tests/spec/object/spec-get.js
@@ -17,6 +17,28 @@ define(
                 expect( get(foo, 'bar.lorem.ipsum') ).toBe( 'dolor' );
             });
 
+            it('should get nested property when encountering non-primitive', function () {
+                var foo = {
+                    bar : {
+                        lorem : function(){}
+                    }
+                };
+                
+                foo.bar.lorem.ipsum = 'dolor'
+
+                expect( get(foo, 'bar.lorem.ipsum') ).toBe( 'dolor' );
+            });
+
+            it('should get nested property when encountering primitive', function () {
+                var foo = {
+                    bar : {
+                        lorem : 'ipsum'
+                    }
+                };
+
+                expect( get(foo, 'bar.lorem.toString') ).toBe( foo.bar.lorem.toString );
+            });
+
             it('should return undefined if non existent', function () {
                 var foo = {
                     bar : {
@@ -34,19 +56,6 @@ define(
 
                 var undef;
                 expect( get(foo, 'foo.bar.baz') ).toBe(undef);
-            });
-
-            it('should return undefined when encountering primitive', function () {
-                var foo = {
-                    bar : {
-                        lorem : 'ipsum'
-                    }
-                };
-                var undef;
-
-                foo.bar.lorem.dolor = 'sit'
-
-                expect( get(foo, 'bar.lorem.dolor') ).toBe( undef );
             });
 
         });


### PR DESCRIPTION
Fix for #177.

Allows retrieval of values from non-primitives.
