### PR TITLE
(#194) - Fixes math.norm and add test specs

### DIFF
--- a/src/math/norm.js
+++ b/src/math/norm.js
@@ -3,7 +3,11 @@ define(function(){
     * Gets normalized ratio of value inside range.
     */
     function norm(val, min, max){
-        return min === max ? val / max : (val - min) / (max - min);
+        if (val < min || val > max) {
+            throw new RangeError('Value must be between ' + min + ' and ' + max);
+        }
+
+        return val === max ? 1 : (val - min) / (max - min);
     }
     return norm;
 });

--- a/tests/spec/math/spec-norm.js
+++ b/tests/spec/math/spec-norm.js
@@ -6,16 +6,16 @@ define(['mout/math/norm'], function (norm) {
             expect( norm(50, 0, 100) ).toEqual(0.5);
             expect( norm(200, 0, 500) ).toEqual(0.4);
             expect( norm(200, 0, 1000) ).toEqual(0.2);
+            expect( norm(1000, 1000, 1001) ).toEqual(0);
         });
 
-        it('should calculate ratio even outside range', function(){
-            expect( norm(1500, 0, 1000) ).toEqual(1.5);
-            expect( norm(-1500, 0, 1000) ).toEqual(-1.5);
+        it('should throw if value outside range', function(){
+            expect( norm.bind(null, 1500, 0, 1000) ).toThrow();
+            expect( norm.bind(null, -1500, 0, 1000) ).toThrow();
         });
 
-        it('should calculate ratio even if min equals max', function(){
+        it('should return 1 if min equals max', function(){
             expect( norm(100, 100, 100) ).toEqual(1);
-            expect( norm(200, 100, 100) ).toEqual(2);
         });
 
     });


### PR DESCRIPTION
As stated on #194, `if min === max === val` we would get a `NaN` as the returned value, which is not the expected (`1`). That happens because we deal with a `0/0`, which returns `NaN`. If `max === min` we would also return something not expected even when val is differnt (it would return `Infinity`).

Fixes #194
