### PR TITLE
Add string/stripMargin

### DIFF
--- a/doc/string.md
+++ b/doc/string.md
@@ -452,6 +452,23 @@ slugify(str); // "loremipsum-dolor-special-chars"
 slugify(str, '_'); // "loremipsum_dolor_special_chars"
 ```
 
+## stripMargin(str[, marginChar]):String
+
+Strip leading characters followed by 'marginChar' from every line in a String.
+The default margin character is a pipe.
+
+### Example
+
+```js
+var str = 'this\n';
+str += '  |is a formatted\n';
+str += '  |string';
+
+
+stripMargin(str); //"this\nis a formatted\nstring"
+stripMargin("this\n___#works\n___#too", '#'); //"this\nworks\ntoo"
+
+```
 
 
 ## trim(str, [chars]):String
@@ -550,7 +567,7 @@ underscore('loremIpsum');                  // "lorem_ipsum"
 
 ## unescapeHtml(str):String
 
-Unescapes the following HTML character references back into the raw symbol they map to: 
+Unescapes the following HTML character references back into the raw symbol they map to:
 
 * `&amp;` becomes `&`
 * `&lt;` becomes `<`
@@ -623,4 +640,3 @@ characters](http://en.wikipedia.org/wiki/Whitespace_character).
 
 For more usage examples check specs inside `/tests` folder. Unit tests are the
 best documentation you can get...
-

--- a/src/string.js
+++ b/src/string.js
@@ -32,6 +32,7 @@ return {
     'slugify' : require('./string/slugify'),
     'startsWith' : require('./string/startsWith'),
     'stripHtmlTags' : require('./string/stripHtmlTags'),
+    'stripMargin' : require('./string/stripMargin'),
     'trim' : require('./string/trim'),
     'truncate' : require('./string/truncate'),
     'typecast' : require('./string/typecast'),

--- a/src/string/stripMargin.js
+++ b/src/string/stripMargin.js
@@ -1,0 +1,21 @@
+define(['../lang/toString', './escapeRegExp'], function (toString, escapeRegExp) {
+    var DEFAULT_MARGIN_CHAR = '|';
+    /**
+     * Strip leading characters followed by 'marginChar' from every line in a String.
+     *
+     * marginChar defaults to '|'.
+     */
+    function stripMargin(str, marginChar) {
+        var regexp;
+
+        marginChar = escapeRegExp(marginChar || DEFAULT_MARGIN_CHAR);
+        str = toString(str);
+
+        regexp = new RegExp('^.*' + marginChar, 'gm');
+
+        return str.replace(regexp, '');
+    }
+
+    return stripMargin;
+
+});

--- a/tests/spec/spec-string.js
+++ b/tests/spec/spec-string.js
@@ -30,6 +30,7 @@ define([
     './string/spec-slugify',
     './string/spec-startsWith',
     './string/spec-stripHtmlTags',
+    './string/spec-stripMargin',
     './string/spec-trim',
     './string/spec-truncate',
     './string/spec-typecast',

--- a/tests/spec/string/spec-stripMargin.js
+++ b/tests/spec/string/spec-stripMargin.js
@@ -1,0 +1,16 @@
+define(['mout/string/stripMargin'], function (stripMargin) {
+
+    describe('string/stripMargin', function () {
+
+        it('should strip leading characters up to | from a string', function () {
+            expect( stripMargin('   |foo') ).toEqual( 'foo' );
+            expect( stripMargin('foo\n    |bar\n    |baz') ).toEqual(
+              'foo\nbar\nbaz');
+        });
+
+        it('should strip leading characters up to "marginChar" from a string', function(){
+            expect( stripMargin('    #foo', '#') ).toBe('foo');
+        });
+    });
+
+});


### PR DESCRIPTION
This function comes in handy when you want to use ES6 multiline strings without breaking indentation. 

It allows you to do the the following:

``` es6
function test () {
    var str = stripMargin(`this is
         |my indented string
         |which is awesome.`);
    return str;
}
// with stripMargin():
//
//this is
//my indented string
//which is awesome.

// without stripMargin():
//
//this is
//        my indented string
//        which is awesome.

```
