### PR TITLE
Minor typo in the docs for object::filter

### DIFF
--- a/doc/object.md
+++ b/doc/object.md
@@ -208,7 +208,7 @@ var obj = {
 };
 
 // returns { bar: 'bar value' }
-filter(obj, function(v) { return value.length > 5; });
+filter(obj, function(v) { return v.length > 5; });
 
 // returns { foo: 'value' }
 filter(obj, function(v, k) { return k === 'foo'; });


### PR DESCRIPTION
Just a minor typo in the example for `filter` where the value reference should be `v` rather than `value`