### PR TITLE
array/empty() utility

### DIFF
--- a/doc/array.md
+++ b/doc/array.md
@@ -104,6 +104,18 @@ var b = ['c', 1];
 difference(a, b); // ['a', 'b']
 ```
 
+## empty(arr):Array
+
+Empties the array. Will modify the passed array instead of returning a new one.
+If value passed is not an array it will return an empty array.
+
+```js
+var arr = [1 ,2 ,3];
+var result = empty(arr);
+
+result === arr; // true
+```
+
 
 ## equals(a, b, [compare]):Boolean
 

--- a/doc/function.md
+++ b/doc/function.md
@@ -19,7 +19,7 @@ the images take 1500 milliseconds to load, it will trigger `onLoaded`
 immediately.
 
 ```js
-var callback = after(onLoaded, 1000);
+var callback = awaitDelay(onLoaded, 1000);
 loadImages(callback);
 function onLoaded(){
     console.log('loaded');

--- a/doc/number.md
+++ b/doc/number.md
@@ -25,9 +25,9 @@ You can set the amount of decimal digits (default is `1`):
 You can customize the abbreviation by passing a custom "dictionary":
 
     var _ptbrDict = {
-        thousands : ' mil',
-        millions : ' Mi',
-        billions : ' Bi'
+        thousand: ' mil',
+        million: ' Mi',
+        billion: ' Bi'
     };
     function customAbbr(val) {
         return abbreviate(val, 1, _ptbrDict);

--- a/src/array.js
+++ b/src/array.js
@@ -9,6 +9,7 @@ return {
     'compact' : require('./array/compact'),
     'contains' : require('./array/contains'),
     'difference' : require('./array/difference'),
+    'empty' : require('./array/empty'),
     'equals' : require('./array/equals'),
     'every' : require('./array/every'),
     'filter' : require('./array/filter'),

--- a/src/array/empty.js
+++ b/src/array/empty.js
@@ -1,0 +1,23 @@
+define(['../lang/isArray'], function(isArray) {
+
+    /**
+     * Array empty
+     */
+
+    function empty(array) {
+        var i, len;
+
+        if(!isArray(array)) {
+            return [];
+        }
+
+        for (i = 0, len = array.length; i < len; i++) {
+            array.pop();
+        }
+
+        return array;
+    }
+
+    return empty;
+
+});

--- a/src/array/empty.js
+++ b/src/array/empty.js
@@ -11,9 +11,7 @@ define(['../lang/isArray'], function(isArray) {
             return [];
         }
 
-        for (i = 0, len = array.length; i < len; i++) {
-            array.pop();
-        }
+        array.length = 0;
 
         return array;
     }

--- a/tests/spec/array/spec-empty.js
+++ b/tests/spec/array/spec-empty.js
@@ -1,0 +1,50 @@
+define(['mout/array/empty', 'mout/lang/isArray'], function(empty, isArray){
+
+    describe('array/empty()', function(){
+
+        it('should empty passed array', function() {
+            // arrange
+            var array = [1, 2, 3, 4, 5];
+
+            // assert
+            expect(empty(array).length).toBe(0);
+        });
+
+        it('should remove all values from the array', function() {
+            // arrange
+            var array, result, i;
+            array = [1, 2, 3, 4, 5];
+
+            // act
+            result = empty(array);
+
+            // assert
+            for (i = 0; i < 5; i++) {
+                expect(result[i]).not.toBeDefined();
+            }
+        });
+
+        it('should modify the passed array instead of returning a new one', function() {
+            // arrange
+            var array = [1, 2, 3, 4, 5];
+
+            // assert
+            expect(empty(array)).toBe(array);
+        });
+
+        it('should return a new array if passed value is not an array', function() {
+            // arrange
+            var value, result;
+            value = '';
+
+            // act
+            result = empty(value);
+
+            // assert
+            expect(isArray(result)).toBe(true);
+            expect(result.length).toBe(0);
+        });
+
+    });
+
+});

--- a/tests/spec/spec-array.js
+++ b/tests/spec/spec-array.js
@@ -7,6 +7,7 @@ define([
     './array/spec-compact',
     './array/spec-contains',
     './array/spec-difference',
+    './array/spec-empty',
     './array/spec-equals',
     './array/spec-every',
     './array/spec-filter',


### PR DESCRIPTION
An utility method to empty an array while preserving the reference. Might be useful when modifying the array is more beneficial than creating a new one; an example of this might be an Angularjs view-model passed around in directives.

Method of emptying the array chosen after reviewing this [jsperf](http://jsperf.com/array-destroy/164).