### PR TITLE
Small changes to make stuff compatible with node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
  language: node_js
  node_js:
    - "0.10"
+   - "0.12"
  script:
    - "npm test --coverage"
    - "jshint src"

--- a/doc/function.md
+++ b/doc/function.md
@@ -19,7 +19,7 @@ the images take 1500 milliseconds to load, it will trigger `onLoaded`
 immediately.
 
 ```js
-var callback = after(onLoaded, 1000);
+var callback = awaitDelay(onLoaded, 1000);
 loadImages(callback);
 function onLoaded(){
     console.log('loaded');

--- a/doc/number.md
+++ b/doc/number.md
@@ -25,9 +25,9 @@ You can set the amount of decimal digits (default is `1`):
 You can customize the abbreviation by passing a custom "dictionary":
 
     var _ptbrDict = {
-        thousands : ' mil',
-        millions : ' Mi',
-        billions : ' Bi'
+        thousand: ' mil',
+        million: ' Mi',
+        billion: ' Bi'
     };
     function customAbbr(val) {
         return abbreviate(val, 1, _ptbrDict);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "istanbul": "~0.1.27",
-    "jasmine-node": "~1.2.2",
+    "jasmine-node": "~1.14.5",
     "requirejs": "2.x",
     "nodefy": "*",
     "mdoc": "~0.3.2",


### PR DESCRIPTION
It seems that travis tests run well in both `0.10` and `0.12` but on my Mac, they always fail in date/diff:

![screen shot 2015-04-11 at 11 11 51](https://cloud.githubusercontent.com/assets/1017236/7101077/f3b179ca-e03b-11e4-8a14-a3a413f4664a.png)