### PR TITLE
Allow for more JS-like notation in object/get

### DIFF
--- a/src/object/get.js
+++ b/src/object/get.js
@@ -1,10 +1,12 @@
 define(['../lang/isPrimitive'], function (isPrimitive) {
 
+    var splitBy = /[\.\[\]]+/;
+
     /**
      * get "nested" object property
      */
     function get(obj, prop){
-        var parts = prop.split('.'),
+        var parts = prop.split(splitBy),
             last = parts.pop();
 
         while (prop = parts.shift()) {


### PR DESCRIPTION
Traverse through arrays and objects using the same notation as native
Javascript. `prop` can now be written like `filter.filters[0].value`
and it will access the properties exactly the same.
