### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,7 @@
     "type": "git",
     "url": "git://github.com/mout/mout.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/mout/mout/issues/"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/