### PR TITLE
replace "+" with " " to decode query string

### DIFF
--- a/src/queryString/getQuery.js
+++ b/src/queryString/getQuery.js
@@ -6,7 +6,7 @@ define(function () {
     function getQuery(url) {
         url = url.replace(/#.*/, ''); //removes hash (to avoid getting hash query)
         var queryString = /\?[a-zA-Z0-9\=\&\%\$\-\_\.\+\!\*\'\(\)\,]+/.exec(url); //valid chars according to: http://www.ietf.org/rfc/rfc1738.txt
-        return (queryString)? decodeURIComponent(queryString[0]) : '';
+        return (queryString)? decodeURIComponent(queryString[0].replace(/\+/g,' ')) : '';
     }
 
     return getQuery;

--- a/tests/spec/queryString/spec-getParam.js
+++ b/tests/spec/queryString/spec-getParam.js
@@ -3,8 +3,8 @@ define(['mout/queryString/getParam'], function (getParam) {
     describe('queryString/getParam()', function () {
 
         it('should parse full URL or query string, get parameter value and typecast by default', function () {
-            var query = "?foo=bar&a=123&b=false&c=null";
-            var url = "http://example.com/?foo=bar&a=123&b=false&c=null";
+            var query = "?foo=bar&a=123&b=false&c=null&q=hello+world";
+            var url = "http://example.com/" + query;
 
             expect( getParam(query, 'foo' ) ).toEqual( 'bar' );
             expect( getParam(query, 'foo' ) ).toEqual( getParam(url, 'foo') );
@@ -12,6 +12,8 @@ define(['mout/queryString/getParam'], function (getParam) {
             expect( getParam(query, 'a'   ) ).toEqual( getParam(url, 'a') );
             expect( getParam(query, 'b'   ) ).toEqual( false );
             expect( getParam(query, 'b'   ) ).toEqual( getParam(url, 'b') );
+            expect( getParam(query, 'q'   ) ).toEqual( 'hello world');
+            expect( getParam(query, 'q'   ) ).toEqual( getParam(url, 'q') );
         });
 
         it('should allow toggling the typecast', function () {

--- a/tests/spec/queryString/spec-getQuery.js
+++ b/tests/spec/queryString/spec-getQuery.js
@@ -6,6 +6,11 @@ define(['mout/queryString/getQuery'], function (getQuery) {
             var q = getQuery("http://example.com/?foo=bar&a=123&b=false&c=null");
             expect( q ).toBe( '?foo=bar&a=123&b=false&c=null' );
         });
+
+        it('should replace "+" with space', function () {
+            var q = getQuery("http://example.com/?q=hello+world&a=123++456&b=false&c=null");
+            expect( q ).toBe( '?q=hello world&a=123  456&b=false&c=null' );
+        });
     });
 
 });


### PR DESCRIPTION
' ' (a white space) is encoded as '+' for query string encoding (www form url encoded). We need to replace it back for decoding.

For example, for query string '?q=hello+world', 'q' should be 'hello world' after decoding.  