### PR TITLE
Improved Bower manifest file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,6 @@ trim_trailing_whitespace = true
 ; The default indent on package.json is 2 spaces, better to keep it so we can
 ; use `npm install --save` and other features that rewrites the package.json
 ; file automatically
-[package.json]
+[{bower,package}.json]
 indent_style = space
 indent_size = 2

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,44 @@
 {
-  "name": "mout",
-  "version": "0.11.0",
-  "main": "src/",
+  "authors": [
+    "Adam Nowotny",
+    "André Cruz <amdfcruz@gmail.com>",
+    "Conrad Zimmerman (http://www.conradz.com)",
+    "Friedemann Altrock <frodenius@gmail.com>",
+    "Igor Almeida <igor.p.almeida@gmail.com>",
+    "Jarrod Overson (http://jarrodoverson.com)",
+    "Miller Medeiros <contact@millermedeiros.com> (http://blog.millermedeiros.com)",
+    "Mathias Paumgarten <mail@mathias-paumgarten.com>",
+    "Zach Shipley"
+  ],
+  "description": "Modular Utilities",
+  "homepage": "http://moutjs.com",
   "ignore": [
-    "_build",
-    "doc",
-    "tests",
+    "_build/",
     ".editorconfig",
+    ".gitignore",
     ".jshintrc",
     ".npmignore",
     ".travis.yml",
     "CHANGELOG.md",
     "CONTRIBUTING.md",
     "build.js",
+    "doc/",
+    "tests/",
     "package.json"
-  ]
+  ],
+  "keywords": [
+    "amd-utils",
+    "functional",
+    "stdlib",
+    "utilities"
+  ],
+  "license": "MIT",
+  "main": "src/index.js",
+  "moduleType": "amd",
+  "name": "mout",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mout/mout.git"
+  },
+  "version": "0.11.0"
 }


### PR DESCRIPTION
- Matched properties with data from “package.json” manifest file
- Fixed entry-point file in `main` property
- Excluded “.gitignore” file from publishing
- Added `moduleType` property
- Applied “package.json” indent to “bower.json” file as well