### PR TITLE
adds array/reverse

### DIFF
--- a/doc/array.md
+++ b/doc/array.md
@@ -698,6 +698,21 @@ removeAll(foo, 2);
 console.log(foo); // [1, 3, 4];
 ```
 
+## reverse(arr):void
+
+Returns a copy of the array with all elements in reversed order.
+
+### Example
+
+```js
+var foo = [1, 2, 3, 4, 5];
+var bar = reverse(foo);
+console.log(bar); // [5, 4, 3, 2, 1];
+
+console.log(foo); // [1, 2, 3, 4, 5];
+```
+
+
 
 
 ## shuffle(arr):Array

--- a/src/array.js
+++ b/src/array.js
@@ -37,6 +37,7 @@ return {
     'reject' : require('./array/reject'),
     'remove' : require('./array/remove'),
     'removeAll' : require('./array/removeAll'),
+    'reverse' : require('./array/reverse'),
     'shuffle' : require('./array/shuffle'),
     'slice' : require('./array/slice'),
     'some' : require('./array/some'),

--- a/src/array/reverse.js
+++ b/src/array/reverse.js
@@ -1,0 +1,14 @@
+define(function () {
+
+    /**
+     * Returns a copy of the array in reversed order.
+     */
+    function reverse(array) {
+        var copy = array.slice();
+        copy.reverse();
+        return copy;
+    }
+
+    return reverse;
+
+});

--- a/tests/spec/array/spec-reverse.js
+++ b/tests/spec/array/spec-reverse.js
@@ -1,0 +1,51 @@
+define(['mout/array/reverse', 'mout/random/rand'], function(reverse, rand){
+
+    describe('array/reverse', function(){
+
+        it('returns a copy of the array', function(){
+
+            var a = [1, 2, 3];
+            var b = reverse(a);
+
+            expect( a === b ).toBe(false);
+        });
+
+        it('reverses the order of the array', function() {
+            var a = [1, 2, 3];
+            var b = reverse(a);
+
+            expect( b[2] ).toBe( a[0] );
+            expect( b[1] ).toBe( a[1] );
+            expect( b[0] ).toBe( a[2] );
+        });
+
+        it('accepts arrays of arbitray size', function() {
+            var length = Math.floor( rand(10, 100) );
+            var a = [];
+
+            for ( var i = 0; i < length; i++ ) {
+                a.push( rand(0, 100000) );
+            }
+
+            var b = reverse(a);
+
+            for ( i = 0; i < length; i++ ) {
+                expect( a[i] ).toBe( b[length - 1 - i] );
+            }
+        });
+
+        it('leaves the order of the original array in tact', function() {
+            var a = [1, 2, 3, 4, 5];
+
+            reverse(a);
+
+            for( var i = 0; i < a.length; i++ ) {
+                expect( a[i] ).toBe( i + 1 );
+            }
+
+            expect( a.length ).toBe( 5 );
+        });
+
+    });
+
+});

--- a/tests/spec/spec-array.js
+++ b/tests/spec/spec-array.js
@@ -35,6 +35,7 @@ define([
     './array/spec-reject',
     './array/spec-remove',
     './array/spec-removeAll',
+    './array/spec-reverse',
     './array/spec-shuffle',
     './array/spec-slice',
     './array/spec-some',


### PR DESCRIPTION
This PR is a proposal to an array/reverse method that returns a copy of the array unlike [Array.prototype.reverse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse) which reverses the elements in place and doesn't return anything. 

I find this method quite useful and therefore wanted to ask if we are pro merge?