### PR TITLE
Adds function/after

### DIFF
--- a/doc/function.md
+++ b/doc/function.md
@@ -17,7 +17,8 @@ var callback = after(onLoaded, imagePaths.length);
 
 forEach(imagePaths, function(path) {
     asyncLoad(path, callback);
-})
+});
+```
 
 ## awaitDelay(fn, delay):Function
 

--- a/doc/function.md
+++ b/doc/function.md
@@ -2,6 +2,22 @@
 
 Function*(al)* utilities.
 
+## after(fn, n):Function
+
+This creates a function that will only call `fn` if it was called `n` or more times.
+
+
+```js
+function onLoaded() {
+    console.log('all images loaded');
+}
+
+var imagePaths = ['1.jpg', '2.jpg', '3.jpg'];
+var callback = after(onLoaded, imagePaths.length);
+
+forEach(imagePaths, function(path) {
+    asyncLoad(path, callback);
+})
 
 ## awaitDelay(fn, delay):Function
 

--- a/src/function.js
+++ b/src/function.js
@@ -3,6 +3,7 @@ define(function(require){
 //automatically generated, do not edit!
 //run `node build` instead
 return {
+    'after' : require('./function/after'),
     'awaitDelay' : require('./function/awaitDelay'),
     'bind' : require('./function/bind'),
     'compose' : require('./function/compose'),

--- a/src/function/after.js
+++ b/src/function/after.js
@@ -4,10 +4,8 @@ define(function () {
      * Calls closure only after callback is called x times
      */
     function after(closure, times){
-        var count = 0;
-
         return function () {
-            if (++count >= times) closure();
+            if (--times <= 0) closure();
         };
     }
 

--- a/src/function/after.js
+++ b/src/function/after.js
@@ -1,0 +1,16 @@
+define(function () {
+
+    /**
+     * Calls closure only after callback is called x times
+     */
+    function after(closure, times){
+        var count = 0;
+
+        return function () {
+            if (++count >= times) closure();
+        };
+    }
+
+    return after;
+
+});

--- a/tests/spec/function/spec-after.js
+++ b/tests/spec/function/spec-after.js
@@ -1,0 +1,53 @@
+define(['mout/function/after'], function(after){
+
+    describe('function/after', function(){
+
+        var count = 0;
+
+        function tick() {
+            count++;
+        }
+
+        beforeEach(function() {
+            count = 0;
+        });
+
+        it('should the callback after appropriate calls', function(){
+
+            var callback = after(tick, 3);
+
+            callback();
+            callback();
+            callback();
+
+            expect( count ).toBe( 1 );
+        });
+
+        it('should not call closure before', function(){
+
+            var callback = after(tick, 5);
+
+            callback();
+            callback();
+            callback();
+            callback();
+
+            expect( count ).toBe( 0 );
+        });
+
+        it('should continue calling the callback after the minimum amount of calls', function(){
+
+            var callback = after(tick, 3);
+
+            callback();
+            callback();
+            callback();
+            callback();
+            callback();
+
+            expect( count ).toBe( 3 );
+        });
+
+    });
+
+});

--- a/tests/spec/spec-function.js
+++ b/tests/spec/spec-function.js
@@ -1,6 +1,7 @@
 //automatically generated, do not edit!
 //run `node build` instead
 define([
+    './function/spec-after',
     './function/spec-awaitDelay',
     './function/spec-bind',
     './function/spec-compose',


### PR DESCRIPTION
This creates a callback that is only executed after n calls. I keep using something like 
```js
if ( ++loaded === total ) callback()
```
and this is a nice little wrapper around it. Syntax is pretty simple:

```js
var callback = after( closure, 5 );

callback();
callback();
callback();
callback();
callback(); // this one will actually call closure
```
