### PR TITLE
Simplify kindOf

### DIFF
--- a/src/lang/kindOf.js
+++ b/src/lang/kindOf.js
@@ -1,20 +1,12 @@
 define(function () {
 
-    var _rKind = /^\[object (.*)\]$/,
-        _toString = Object.prototype.toString,
-        UNDEF;
+    var _toString = Object.prototype.toString;
 
     /**
      * Gets the "kind" of value. (e.g. "String", "Number", etc)
      */
     function kindOf(val) {
-        if (val === null) {
-            return 'Null';
-        } else if (val === UNDEF) {
-            return 'Undefined';
-        } else {
-            return _rKind.exec( _toString.call(val) )[1];
-        }
+        return _toString.call(val).slice(8, -1)
     }
     return kindOf;
 });

--- a/src/lang/kindOf.js
+++ b/src/lang/kindOf.js
@@ -1,12 +1,9 @@
 define(function () {
-
-    var _toString = Object.prototype.toString;
-
     /**
      * Gets the "kind" of value. (e.g. "String", "Number", etc)
      */
     function kindOf(val) {
-        return _toString.call(val).slice(8, -1);
+        return Object.prototype.toString.call(val).slice(8, -1);
     }
     return kindOf;
 });

--- a/src/lang/kindOf.js
+++ b/src/lang/kindOf.js
@@ -6,7 +6,7 @@ define(function () {
      * Gets the "kind" of value. (e.g. "String", "Number", etc)
      */
     function kindOf(val) {
-        return _toString.call(val).slice(8, -1)
+        return _toString.call(val).slice(8, -1);
     }
     return kindOf;
 });


### PR DESCRIPTION
Object.prototype.toString actually handles `null` and `undefined` pretty well, see http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.4.2

---

You can squash the commits when you merge right here on GitHub nowadays, so I hope the fix commit is fine.