### PR TITLE
Use Function.prototype.bind to support ES6 classes

### DIFF
--- a/src/lang/ctorApply.js
+++ b/src/lang/ctorApply.js
@@ -6,8 +6,8 @@ define(function () {
      * Do fn.apply on a constructor.
      */
     function ctorApply(ctor, args) {
-        var bound = bind.bind(ctor, undefined).apply(undefined, args);
-        return new bound();
+        var Bound = bind.bind(ctor, undefined).apply(undefined, args);
+        return new Bound();
     }
 
     return ctorApply;

--- a/src/lang/ctorApply.js
+++ b/src/lang/ctorApply.js
@@ -1,15 +1,13 @@
 define(function () {
 
-    function F(){}
+    var bind = Function.protype.bind;
 
     /**
      * Do fn.apply on a constructor.
      */
     function ctorApply(ctor, args) {
-        F.prototype = ctor.prototype;
-        var instance = new F();
-        ctor.apply(instance, args);
-        return instance;
+        var bound = bind.bind(ctor, undefined).apply(undefined, args);
+        return new bound();
     }
 
     return ctorApply;

--- a/src/lang/ctorApply.js
+++ b/src/lang/ctorApply.js
@@ -1,6 +1,6 @@
 define(function () {
 
-    var bind = Function.protype.bind;
+    var bind = Function.prototype.bind;
 
     /**
      * Do fn.apply on a constructor.


### PR DESCRIPTION
By using `bind` it will work both with old style functions as classes and the new proper classes in ES2015.

This may be a slightly more hidden property of `bind`, but when called with `new` it discards the stored `this` value and constructs rather calls the original function/class. The double bind/apply is to splat the args properly while keeping it as a bound function.

Without bind it throws an error when you use native ES2015 classes, like in modern chrome:

```javascript
> class Foo {}
> function F() {}
> F.prototype = Foo.prototype
> instance = new F()
> Foo.apply(instance, [1, 2, 3])
Uncaught TypeError: Class constructor Foo cannot be invoked without 'new'
    at <anonymous>:1:5
```

---

You can squash the commits when you merge right here on GitHub nowadays, so I hope the fix commit is fine.