### PR TITLE
docs: Fix simple typo, delimeter -> delimiter

### DIFF
--- a/doc/string.md
+++ b/doc/string.md
@@ -435,10 +435,10 @@ startsWith('lorem ipsum', 'ipsum'); // false
 
 
 
-## slugify(str[, delimeter]):String
+## slugify(str[, delimiter]):String
 
 Convert to lower case, remove accents, remove non-word chars and replace spaces
-with the delimeter. The default delimeter is a hyphen.
+with the delimiter. The default delimiter is a hyphen.
 
 Note that this does not split camelCase text.
 

--- a/src/string/slugify.js
+++ b/src/string/slugify.js
@@ -1,19 +1,19 @@
 define(['../lang/toString', './replaceAccents', './removeNonWord', './trim'], function(toString, replaceAccents, removeNonWord, trim){
     /**
      * Convert to lower case, remove accents, remove non-word chars and
-     * replace spaces with the specified delimeter.
+     * replace spaces with the specified delimiter.
      * Does not split camelCase text.
      */
-    function slugify(str, delimeter){
+    function slugify(str, delimiter){
         str = toString(str);
 
-        if (delimeter == null) {
-            delimeter = "-";
+        if (delimiter == null) {
+            delimiter = "-";
         }
         str = replaceAccents(str);
         str = removeNonWord(str);
         str = trim(str) //should come after removeNonWord
-                .replace(/ +/g, delimeter) //replace spaces with delimeter
+                .replace(/ +/g, delimiter) //replace spaces with delimiter
                 .toLowerCase();
         return str;
     }


### PR DESCRIPTION
There is a small typo in doc/string.md, src/string/slugify.js.

Should read `delimiter` rather than `delimeter`.

